### PR TITLE
Improve dark bootstrap frontend

### DIFF
--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, UploadFile, File
 from fastapi.responses import HTMLResponse
 from pathlib import Path
 
+import config
+
 from ..agents.uploader_agent import UploaderAgent
 from ..agents.metadata_extractor_agent import MetadataExtractorAgent
 from ..agents.indexing_agent import IndexingAgent
@@ -12,7 +14,7 @@ router = APIRouter()
 uploader = UploaderAgent()
 extractor = MetadataExtractorAgent()
 indexer = IndexingAgent()
-frontend = FrontendAgent(Path(uploader.upload_dir))
+frontend = FrontendAgent(Path(uploader.upload_dir), Path(config.TEMPLATE_DIR))
 
 @router.post('/upload')
 async def upload(files: list[UploadFile] = File(...)):
@@ -32,3 +34,12 @@ async def search(query: str):
 async def grid():
     entries = indexer.search('*')
     return frontend.render_grid(entries)
+
+
+@router.get('/detail/{filename}', response_class=HTMLResponse)
+async def detail(filename: str):
+    results = indexer.search(f'"{filename}"')
+    entry = results[0] if results else {"filename": filename}
+    meta = extractor.extract(Path(uploader.upload_dir) / filename)
+    entry["metadata"] = meta
+    return frontend.render_detail(entry)

--- a/loradb/templates/base.html
+++ b/loradb/templates/base.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title or 'LoRA Database' }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-VkAN1YcCQjfKh5rLm1AHTkKQTEKQteA94ppIqh+ap5bvlA38nSxrdbidKdvUS9GD" crossorigin="anonymous">
+  </head>
+  <body class="bg-dark text-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-secondary mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/">LoRA DB</a>
+        <div class="collapse navbar-collapse">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="/grid">Gallery</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container">
+      {% block content %}{% endblock %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Zenh87qX5JnK2JlAKP93w4Koyr5u5a63Y9Vn0eE5t0XKFuNHK08Kf+X8DP0Fi5yw" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">{{ entry.name or entry.filename }}</h1>
+<div class="row mb-3">
+  {% for img in entry.previews %}
+  <div class="col-6 col-md-4 col-lg-3 mb-2">
+    <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
+  </div>
+  {% endfor %}
+</div>
+<table class="table table-dark table-striped">
+  <tbody>
+    {% for key, value in entry.metadata.items() %}
+    <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<a class="btn btn-primary" href="/uploads/{{ entry.filename }}" download>Download</a>
+{% endblock %}

--- a/loradb/templates/grid.html
+++ b/loradb/templates/grid.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">LoRA Gallery</h1>
+<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3">
+  {% for entry in entries %}
+  <div class="col">
+    <div class="card h-100 bg-secondary text-light">
+      {% if entry.preview_url %}
+      <img src="{{ entry.preview_url }}" class="card-img-top" alt="preview">
+      {% endif %}
+      <div class="card-body p-2">
+        <h5 class="card-title small">{{ entry.name or entry.filename }}</h5>
+        <a href="/detail/{{ entry.filename }}" class="stretched-link"></a>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/loradb/templates/index.html
+++ b/loradb/templates/index.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">LoRA Database</h1>
+<p>Upload endpoint: /upload</p>
+<p><a href="/grid" class="btn btn-primary">View Gallery</a></p>
+{% endblock %}

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
 
 import config
 from loradb.api import router as api_router
@@ -9,15 +10,18 @@ from loradb.api import router as api_router
 app = FastAPI(title="LoRA Database")
 
 app.mount("/static", StaticFiles(directory=config.STATIC_DIR), name="static")
+app.mount("/uploads", StaticFiles(directory=config.UPLOAD_DIR), name="uploads")
 
 UPLOAD_DIR = Path(config.UPLOAD_DIR)
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+env = Environment(loader=FileSystemLoader(config.TEMPLATE_DIR))
 
 app.include_router(api_router)
 
 @app.get("/", response_class=HTMLResponse)
 async def index():
-    return "<h1>LoRA Database</h1><p>Upload endpoint: /upload</p><p><a href='/grid'>View Gallery</a></p>"
+    template = env.get_template("index.html")
+    return template.render(title="LoRA Database")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 safetensors
 python-multipart
 Pillow
+Jinja2


### PR DESCRIPTION
## Summary
- add Bootstrap-based base, index, grid and detail templates
- enhance FrontendAgent with Jinja2 support for previews
- mount uploads, use templates in main app
- expose detail route and render grid with previews
- include Jinja2 in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b0b03df9883339c5b2087da981267