### PR TITLE
Fix relative path issues

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,16 @@
-UPLOAD_DIR = 'loradb/uploads'
-STATIC_DIR = 'loradb/static'
-TEMPLATE_DIR = 'loradb/templates'
+"""Configuration for paths used by the application."""
+
+from pathlib import Path
+
+# Resolve all paths relative to this config file so running the app from any
+# working directory still picks up the correct folders.
+BASE_DIR = Path(__file__).resolve().parent
+
+# Directory to store uploaded LoRA files and preview images
+UPLOAD_DIR = BASE_DIR / "loradb" / "uploads"
+
+# Directory with static assets such as CSS
+STATIC_DIR = BASE_DIR / "loradb" / "static"
+
+# Directory containing Jinja2 templates
+TEMPLATE_DIR = BASE_DIR / "loradb" / "templates"


### PR DESCRIPTION
## Summary
- fix config paths so static assets and templates load from any working directory

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b0f4651ec8333acf94d9de0d6f93d