### PR TITLE
Add preview zip upload and update grid view

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A web-based management platform for LoRA files (.safetensors) with preview suppo
 
 ## ✨ Features
 
-* ⬆️ **Bulk Upload** of `.safetensors` LoRA files and preview images
+* ⬆️ **Bulk Upload** of `.safetensors` LoRA files
+* 📦 **Preview Upload via ZIP** for each LoRA
 * 🌐 **Dark Mode Interface** in modern grid gallery design
 * ⚙️ **Automatic Metadata Extraction** including training tags
 * ⚡ **Search by Name and Tags**, powered by indexed metadata
@@ -57,7 +58,8 @@ Default port: `http://ServerIP:5000`
 
 ### API Endpoints
 
-* `POST /upload` - upload one or more `.safetensors` or preview images
+* `POST /upload` - upload one or more `.safetensors` files
+* `POST /upload_previews` - upload a zip containing preview images
 * `GET /search?query=<term>` - search indexed metadata
 * `GET /grid` - simple gallery view of all indexed files
 

--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -35,6 +35,20 @@ async def upload(request: Request, files: list[UploadFile] = File(...)):
         return RedirectResponse(url='/grid', status_code=303)
     return results
 
+
+@router.get('/upload_previews', response_class=HTMLResponse)
+async def upload_previews_form():
+    """Form for uploading preview zip files."""
+    return frontend.env.get_template('upload_previews.html').render(title='Upload Previews')
+
+
+@router.post('/upload_previews')
+async def upload_previews(request: Request, file: UploadFile = File(...)):
+    uploader.save_preview_zip(file)
+    if 'text/html' in request.headers.get('accept', ''):
+        return RedirectResponse(url='/grid', status_code=303)
+    return {"status": "ok"}
+
 @router.get('/search')
 async def search(query: str):
     return indexer.search(query)

--- a/loradb/templates/base.html
+++ b/loradb/templates/base.html
@@ -15,6 +15,7 @@
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item"><a class="nav-link" href="/grid">Gallery</a></li>
             <li class="nav-item"><a class="nav-link" href="/upload">Upload</a></li>
+            <li class="nav-item"><a class="nav-link" href="/upload_previews">Upload Previews</a></li>
           </ul>
         </div>
       </div>

--- a/loradb/templates/index.html
+++ b/loradb/templates/index.html
@@ -3,6 +3,7 @@
 <h1 class="mb-4">LoRA Database</h1>
 <p>
   <a href="/upload" class="btn btn-success me-2">Upload Files</a>
+  <a href="/upload_previews" class="btn btn-secondary me-2">Upload Previews</a>
   <a href="/grid" class="btn btn-primary">View Gallery</a>
 </p>
 {% endblock %}

--- a/loradb/templates/upload_previews.html
+++ b/loradb/templates/upload_previews.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Upload Preview Zip</h1>
+<form method="post" action="/upload_previews" enctype="multipart/form-data">
+  <div class="mb-3">
+    <input class="form-control" type="file" name="file" accept=".zip" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Upload</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support uploading preview images as zip files
- extract previews and link them to the LoRA
- add dedicated preview upload page
- update navigation and landing page
- document new API endpoint and feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b1078607c833394c3a7441b270a9d