### PR TITLE
Fix missing torch dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ safetensors
 python-multipart
 Pillow
 Jinja2
+
+torch
+


### PR DESCRIPTION
## Summary
- add `torch` to `requirements.txt`

## Testing
- `python -m pip install -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684b138d3fb88333abea66fc90caa3c6