### PR TITLE
Enhance detail view layout

### DIFF
--- a/loradb/static/style.css
+++ b/loradb/static/style.css
@@ -33,3 +33,17 @@ h1 { margin-top: 1rem; }
   font-size: 0.8rem;
   text-align: center;
 }
+
+/* Grid for preview images in the detail view */
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.5rem;
+}
+
+/* Metadata table formatting */
+.metadata-table th,
+.metadata-table td {
+  word-break: break-all;
+  white-space: pre-wrap;
+}

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -1,19 +1,19 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">{{ entry.name or entry.filename }}</h1>
-<div class="row mb-3">
+<div class="preview-grid mb-3">
   {% for img in entry.previews %}
-  <div class="col-6 col-md-4 col-lg-3 mb-2">
-    <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
-  </div>
+  <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
   {% endfor %}
 </div>
-<table class="table table-dark table-striped">
-  <tbody>
-    {% for key, value in entry.metadata.items() %}
-    <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
-    {% endfor %}
-  </tbody>
-</table>
+<div class="table-responsive">
+  <table class="table table-dark table-striped metadata-table">
+    <tbody>
+      {% for key, value in entry.metadata.items() %}
+      <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
 <a class="btn btn-primary" href="/uploads/{{ entry.filename }}" download>Download</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show preview images in a grid on the detail page
- wrap long metadata fields so they are readable
- CSS support for preview grid and metadata table

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1cbd04688333a6e18a7f3f800f9f