### PR TITLE
Improve detail preview grid and metadata table

### DIFF
--- a/loradb/static/style.css
+++ b/loradb/static/style.css
@@ -41,9 +41,23 @@ h1 { margin-top: 1rem; }
   gap: 0.5rem;
 }
 
+.preview-grid img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 /* Metadata table formatting */
 .metadata-table th,
 .metadata-table td {
   word-break: break-all;
   white-space: pre-wrap;
+}
+
+.metadata-table {
+  table-layout: fixed;
+}
+
+.metadata-table th {
+  width: 25%;
 }

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -9,7 +9,7 @@
 <div class="table-responsive">
   <table class="table table-dark table-striped metadata-table">
     <tbody>
-      {% for key, value in entry.metadata.items() %}
+      {% for key, value in entry.metadata|dictsort %}
       <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- tweak grid layout for preview images on detail page
- refine metadata table styling
- sort metadata keys in template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b1de68f5c8333a4c699f40989e586