### PR TITLE
Make tensor_keys optional

### DIFF
--- a/loradb/agents/metadata_extractor_agent.py
+++ b/loradb/agents/metadata_extractor_agent.py
@@ -6,15 +6,25 @@ from safetensors import safe_open
 class MetadataExtractorAgent:
     """Extract metadata from LoRA files."""
 
-    def extract(self, filepath: Path) -> Dict[str, str]:
-        """Extract basic metadata from a safetensors file."""
+    def extract(self, filepath: Path, include_tensor_keys: bool = False) -> Dict[str, str]:
+        """Extract basic metadata from a safetensors file.
+
+        Parameters
+        ----------
+        filepath:
+            The safetensors file to read metadata from.
+        include_tensor_keys:
+            Whether to include the list of tensor keys from the file. Disabled by
+            default as these can be very large.
+        """
         metadata = {"filename": filepath.name}
         try:
             with safe_open(str(filepath), framework="pt") as f:
                 meta = f.metadata() or {}
                 metadata.update(meta)
-                keys = list(f.keys())
-                metadata["tensor_keys"] = ",".join(keys)
+                if include_tensor_keys:
+                    keys = list(f.keys())
+                    metadata["tensor_keys"] = ",".join(keys)
         except Exception as exc:
             metadata["error"] = str(exc)
         return metadata


### PR DESCRIPTION
## Summary
- allow `MetadataExtractorAgent.extract()` to skip collecting tensor keys

## Testing
- `python -m py_compile loradb/agents/metadata_extractor_agent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2169c16c83338d9f14512e8bce24