### PR TITLE
Add selectable deletion for files

### DIFF
--- a/loradb/agents/indexing_agent.py
+++ b/loradb/agents/indexing_agent.py
@@ -99,3 +99,11 @@ class IndexingAgent:
         for file in uploads.glob("*.safetensors"):
             meta = extractor.extract(file)
             self.add_metadata(meta)
+
+    def remove_metadata(self, filename: str) -> None:
+        """Remove a LoRA entry from the index by filename."""
+        self.conn.execute(
+            "DELETE FROM lora_index WHERE filename = ?",
+            (filename,),
+        )
+        self.conn.commit()

--- a/loradb/agents/uploader_agent.py
+++ b/loradb/agents/uploader_agent.py
@@ -63,3 +63,19 @@ class UploaderAgent:
                     extracted.append(dest)
                     index += 1
         return extracted
+
+    def delete_lora(self, filename: str) -> None:
+        """Delete a LoRA file and all associated preview images."""
+        path = self.upload_dir / filename
+        if path.exists():
+            path.unlink()
+        stem = Path(filename).stem
+        for ext in [".png", ".jpg", ".jpeg", ".gif"]:
+            for p in self.upload_dir.glob(f"{stem}*{ext}"):
+                p.unlink(missing_ok=True)
+
+    def delete_preview(self, filename: str) -> None:
+        """Delete a single preview image."""
+        path = self.upload_dir / filename
+        if path.exists():
+            path.unlink()

--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -69,3 +69,21 @@ async def detail(filename: str):
     meta = extractor.extract(Path(uploader.upload_dir) / filename)
     entry["metadata"] = meta
     return frontend.render_detail(entry)
+
+
+@router.post('/delete')
+async def delete_files(request: Request):
+    """Delete selected LoRA or preview files."""
+    form = await request.form()
+    files = form.getlist('files')
+    deleted = []
+    for fname in files:
+        if fname.endswith('.safetensors'):
+            uploader.delete_lora(fname)
+            indexer.remove_metadata(fname)
+        else:
+            uploader.delete_preview(fname)
+        deleted.append(fname)
+    if 'text/html' in request.headers.get('accept', ''):
+        return RedirectResponse(url='/grid', status_code=303)
+    return {'deleted': deleted}

--- a/loradb/static/style.css
+++ b/loradb/static/style.css
@@ -35,6 +35,13 @@ h1 { margin-top: 1rem; font-weight: 600; }
   object-fit: cover;
 }
 
+.gallery-item input[type="checkbox"] {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  z-index: 2;
+}
+
 .gallery-item .title-overlay {
   position: absolute;
   bottom: 0;
@@ -61,6 +68,13 @@ h1 { margin-top: 1rem; font-weight: 600; }
   object-fit: cover;
   border-radius: 0.5rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.preview-grid input[type="checkbox"] {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  z-index: 2;
 }
 
 /* Metadata table formatting */

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -1,11 +1,19 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">{{ entry.name or entry.filename }}</h1>
-<div class="preview-grid mb-3">
-  {% for img in entry.previews %}
-  <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
-  {% endfor %}
-</div>
+<form method="post" action="/delete">
+  <div class="d-flex justify-content-end mb-2">
+    <button class="btn btn-danger btn-sm" type="submit">Remove Selected</button>
+  </div>
+  <div class="preview-grid mb-3">
+    {% for img in entry.previews %}
+    <div class="position-relative">
+      <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
+      <input class="form-check-input position-absolute top-0 end-0 m-1" type="checkbox" name="files" value="{{ img|replace('/uploads/','') }}">
+    </div>
+    {% endfor %}
+  </div>
+</form>
 <div class="table-responsive">
   <table class="table table-dark table-striped metadata-table">
     <tbody>

--- a/loradb/templates/grid.html
+++ b/loradb/templates/grid.html
@@ -5,16 +5,22 @@
   <input type="text" class="form-control" name="q" placeholder="Search" value="{{ query }}">
   <button class="btn btn-outline-secondary" type="submit">&#128269;</button>
 </form>
-<div class="gallery-grid">
-  {% for entry in entries %}
-  <div class="gallery-item">
-    {% if entry.preview_url %}
-    <img src="{{ entry.preview_url }}" alt="preview">
-    {% endif %}
-    <div class="title-overlay">
-      <a href="/detail/{{ entry.filename }}" class="stretched-link text-light text-decoration-none">{{ entry.name or entry.filename }}</a>
-    </div>
+<form method="post" action="/delete">
+  <div class="d-flex justify-content-end mb-2">
+    <button class="btn btn-danger btn-sm" type="submit">Remove Selected</button>
   </div>
-  {% endfor %}
-</div>
+  <div class="gallery-grid">
+    {% for entry in entries %}
+    <div class="gallery-item position-relative">
+      {% if entry.preview_url %}
+      <img src="{{ entry.preview_url }}" alt="preview">
+      {% endif %}
+      <input class="form-check-input position-absolute m-2 top-0 end-0" type="checkbox" name="files" value="{{ entry.filename }}">
+      <div class="title-overlay">
+        <a href="/detail/{{ entry.filename }}" class="stretched-link text-light text-decoration-none">{{ entry.name or entry.filename }}</a>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow deleting LoRA or preview files
- overlay delete checkboxes on grid and detail views
- style delete checkbox overlays

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b32c175d483339548eae0ea5db7f6