### PR TITLE
Add setup automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,28 +31,21 @@ requirements.txt       # Python dependencies
 
 ## Installation
 
-1. Clone the repository and change into the project folder:
+Run the setup script directly from GitHub:
 
-   ```bash
-   git clone https://github.com/AsaTyr2018/MyLora.git
-   cd MyLora
-   ```
+```bash
+curl -sL https://raw.githubusercontent.com/AsaTyr2018/MyLora/main/setup.sh | sudo bash -s install
+```
 
-2. Create a virtual environment (optional but recommended) and install the dependencies:
+If you cloned the repository manually run:
 
-   ```bash
-   python -m venv venv
-   source venv/bin/activate
-   pip install -r requirements.txt
-   ```
+```bash
+sudo ./setup.sh install      # install
+sudo ./setup.sh update       # update
+sudo ./setup.sh uninstall    # remove
+```
 
-3. Start the web application:
-
-   ```bash
-   python main.py
-   ```
-
-   The interface is available on [http://localhost:5000](http://localhost:5000).
+After installation the interface is available on [http://localhost:5000](http://localhost:5000).
 
 ## Usage
 

--- a/mylora.service
+++ b/mylora.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=LoRA database web interface
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/MyLora
+ExecStart=/opt/MyLora/venv/bin/python /opt/MyLora/main.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -e
+
+REPO_URL="https://github.com/AsaTyr2018/MyLora.git"
+INSTALL_DIR="/opt/MyLora"
+SERVICE_FILE="/etc/systemd/system/mylora.service"
+VENV_DIR="$INSTALL_DIR/venv"
+
+check_root() {
+    if [[ $EUID -ne 0 ]]; then
+        echo "This script must be run as root" >&2
+        exit 1
+    fi
+}
+
+clone_repo() {
+    tmpdir="$HOME/MyLora"
+    rm -rf "$tmpdir"
+    git clone "$REPO_URL" "$tmpdir"
+    rm -rf "$INSTALL_DIR"
+    mv "$tmpdir" "$INSTALL_DIR"
+    chown -R root:root "$INSTALL_DIR"
+}
+
+setup_venv() {
+    python3 -m venv "$VENV_DIR"
+    "$VENV_DIR/bin/pip" install --upgrade pip
+    "$VENV_DIR/bin/pip" install -r "$INSTALL_DIR/requirements.txt"
+}
+
+create_service() {
+    cat > "$SERVICE_FILE" <<SERVICE
+[Unit]
+Description=LoRA database web interface
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$VENV_DIR/bin/python $INSTALL_DIR/main.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+    systemctl daemon-reload
+    systemctl enable mylora.service
+}
+
+install_app() {
+    clone_repo
+    setup_venv
+    create_service
+    systemctl start mylora.service
+    echo "MyLora installed in $INSTALL_DIR"
+}
+
+update_app() {
+    if [[ ! -d $INSTALL_DIR ]]; then
+        echo "MyLora is not installed" >&2
+        exit 1
+    fi
+    git -C "$INSTALL_DIR" pull
+    "$VENV_DIR/bin/pip" install -r "$INSTALL_DIR/requirements.txt"
+    systemctl restart mylora.service
+    echo "MyLora updated"
+}
+
+uninstall_app() {
+    systemctl stop mylora.service || true
+    systemctl disable mylora.service || true
+    rm -f "$SERVICE_FILE"
+    systemctl daemon-reload
+    rm -rf "$INSTALL_DIR"
+    echo "MyLora removed"
+}
+
+case "$1" in
+    install)
+        check_root
+        install_app
+        ;;
+    update)
+        check_root
+        update_app
+        ;;
+    uninstall)
+        check_root
+        uninstall_app
+        ;;
+    *)
+        echo "Usage: $0 {install|update|uninstall}"
+        exit 1
+        ;;
+ esac
+


### PR DESCRIPTION
## Summary
- add setup script for install/update/uninstall
- provide service definition
- simplify installation section in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_684b3ba7b7f88333a5b900f93e982a8c