### PR TITLE
Add category management

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project provides a minimal FastAPI application for organising LoRA files (`
 - **Searchable gallery** – browse all indexed LoRAs in a grid view and filter by query.
 - **Detail view** – see all previews, metadata and a download link for a single LoRA.
 - **File removal** – delete LoRA files or individual preview images from the interface.
+- **Category management** – organise LoRAs into categories and filter the gallery accordingly.
 
 ## Project layout
 
@@ -54,6 +55,7 @@ After installation the interface is available on [http://localhost:5000](http://
 - **Browse and search**: the `/grid` page lists all indexed LoRAs. Use the search box to filter by filename or tags.
 - **Detail view**: click a LoRA in the gallery to view all previews and metadata.  A download button is provided to retrieve the original file.
 - **Delete files**: tick the checkboxes in the gallery or detail view and press *Remove Selected* to delete the chosen files.
+- **Categories**: add categories via the API or detail page and use the dropdown on the gallery page to filter.
 
 ### Bulk import
 
@@ -67,6 +69,18 @@ python bulk_import.py /path/to/safetensors /path/to/images
 
 Every model will be copied into `loradb/uploads`, its metadata extracted and
 added to the search index so it appears in the web interface automatically.
+
+### Category migration
+
+Existing installations can populate the new category tables based on text files
+located next to each LoRA file. Run
+
+```bash
+python migrate_categories.py
+```
+
+Each `<name>.txt` file should contain a comma or newline separated list of
+categories which will be created and assigned to `<name>.safetensors`.
 
 The web pages use Bootstrap via a CDN and are rendered with Jinja2 templates.  The application keeps all data locally on disk in the `loradb` directory.
 

--- a/loradb/agents/frontend_agent.py
+++ b/loradb/agents/frontend_agent.py
@@ -26,18 +26,32 @@ class FrontendAgent:
         # convert to URLs
         return [f"/uploads/{Path(m).name}" for m in matches]
 
-    def render_grid(self, entries: List[Dict[str, str]], query: str | None = None) -> str:
+    def render_grid(
+        self,
+        entries: List[Dict[str, str]],
+        query: str | None = None,
+        categories: List[Dict[str, str]] | None = None,
+        selected_category: str | None = None,
+    ) -> str:
         for e in entries:
             stem = Path(e.get("filename", "")).stem
             previews = self._find_previews(stem)
             e["preview_url"] = random.choice(previews) if previews else None
         template = self.env.get_template("grid.html")
-        return template.render(title="LoRA Gallery", entries=entries, query=query or "")
+        return template.render(
+            title="LoRA Gallery",
+            entries=entries,
+            query=query or "",
+            categories=categories or [],
+            selected_category=selected_category or "",
+        )
 
-    def render_detail(self, entry: Dict[str, str]) -> str:
+    def render_detail(
+        self, entry: Dict[str, str], categories: List[Dict[str, str]] | None = None
+    ) -> str:
         stem = Path(entry.get("filename", "")).stem
         previews = self._find_previews(stem)
         entry["previews"] = previews
         entry.setdefault("metadata", {})
         template = self.env.get_template("detail.html")
-        return template.render(title=entry.get("name"), entry=entry)
+        return template.render(title=entry.get("name"), entry=entry, categories=categories or [])

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -1,6 +1,29 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">{{ entry.name or entry.filename }}</h1>
+<div class="mb-3">
+  Categories:
+  {% if entry.categories %}
+    {% for cat in entry.categories %}
+    <span class="badge bg-secondary">{{ cat }}</span>
+    {% endfor %}
+  {% else %}
+    <span class="text-muted">None</span>
+  {% endif %}
+</div>
+{% if categories %}
+<form method="post" action="/assign_category" class="mb-3" style="max-width: 300px;">
+  <input type="hidden" name="filename" value="{{ entry.filename }}">
+  <div class="input-group">
+    <select class="form-select" name="category_id">
+      {% for cat in categories %}
+      <option value="{{ cat.id }}">{{ cat.name }}</option>
+      {% endfor %}
+    </select>
+    <button class="btn btn-outline-primary" type="submit">Add</button>
+  </div>
+</form>
+{% endif %}
 <form method="post" action="/delete">
   <div class="d-flex justify-content-end mb-2">
     <button class="btn btn-danger btn-sm" type="submit">Remove Selected</button>

--- a/loradb/templates/grid.html
+++ b/loradb/templates/grid.html
@@ -1,9 +1,21 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">LoRA Gallery</h1>
-<form method="get" action="/grid" class="input-group mb-3" style="max-width: 400px;">
-  <input type="text" class="form-control" name="q" placeholder="Search" value="{{ query }}">
-  <button class="btn btn-outline-secondary" type="submit">&#128269;</button>
+<form method="get" action="/grid" class="row g-2 mb-3" style="max-width: 600px;">
+  <div class="col">
+    <input type="text" class="form-control" name="q" placeholder="Search" value="{{ query }}">
+  </div>
+  <div class="col">
+    <select class="form-select" name="category">
+      <option value="">All categories</option>
+      {% for cat in categories %}
+      <option value="{{ cat.id }}" {% if selected_category==cat.id|string %}selected{% endif %}>{{ cat.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-auto">
+    <button class="btn btn-outline-secondary" type="submit">&#128269;</button>
+  </div>
 </form>
 <form method="post" action="/delete">
   <div class="d-flex justify-content-end mb-2">
@@ -18,6 +30,13 @@
       <input class="form-check-input position-absolute m-2 top-0 end-0" type="checkbox" name="files" value="{{ entry.filename }}">
       <div class="title-overlay">
         <a href="/detail/{{ entry.filename }}" class="stretched-link text-light text-decoration-none">{{ entry.name or entry.filename }}</a>
+        {% if entry.categories %}
+        <div class="small text-info">
+          {% for cat in entry.categories %}
+            {{ cat }}{% if not loop.last %}, {% endif %}
+          {% endfor %}
+        </div>
+        {% endif %}
       </div>
     </div>
     {% endfor %}

--- a/migrate_categories.py
+++ b/migrate_categories.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from loradb.agents import IndexingAgent
+
+
+def main() -> None:
+    uploads = Path('loradb/uploads')
+    indexer = IndexingAgent()
+    for txt in uploads.glob('*.txt'):
+        stem = txt.stem
+        lora_file = uploads / f'{stem}.safetensors'
+        if not lora_file.exists():
+            continue
+        with txt.open('r', encoding='utf-8') as f:
+            content = f.read()
+        categories = [c.strip() for c in content.replace(',', '\n').splitlines() if c.strip()]
+        for cat in categories:
+            cid = indexer.create_category(cat)
+            indexer.assign_category(lora_file.name, cid)
+    print('Migration complete')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- support categories in search index and API
- enable category filtering, display and assignment in templates
- provide migration script for old installs
- document new functionality

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad422c2288333b7bec13eff5d2f23