### PR TITLE
Add UI category creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ After installation the interface is available on [http://localhost:5000](http://
 - **Browse and search**: the `/grid` page lists all indexed LoRAs. Use the search box to filter by filename or tags.
 - **Detail view**: click a LoRA in the gallery to view all previews and metadata.  A download button is provided to retrieve the original file.
 - **Delete files**: tick the checkboxes in the gallery or detail view and press *Remove Selected* to delete the chosen files.
-- **Categories**: add categories via the API or detail page and use the dropdown on the gallery page to filter.
+- **Categories**: create new categories using the form on a LoRA's detail page (or via the API) and use the dropdown on the gallery page to filter.
 
 ### Bulk import
 

--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -76,8 +76,12 @@ async def list_categories():
 
 
 @router.post('/categories')
-async def create_category(name: str = Form(...)):
+async def create_category(request: Request, name: str = Form(...)):
+    """Create a new category and optionally redirect for HTML forms."""
     cid = indexer.create_category(name)
+    if 'text/html' in request.headers.get('accept', ''):
+        referer = request.headers.get('referer', '/grid')
+        return RedirectResponse(url=referer, status_code=303)
     return {'id': cid}
 
 

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -24,6 +24,12 @@
       <button class="btn btn-outline-primary" type="submit">Add</button>
     </div>
   </form>
+  <form method="post" action="/categories" style="max-width: 300px;">
+    <div class="input-group">
+      <input type="text" class="form-control" name="name" placeholder="New category">
+      <button class="btn btn-outline-secondary" type="submit">Create</button>
+    </div>
+  </form>
   {% endif %}
   <a class="btn btn-primary" href="/uploads/{{ entry.filename }}" download>Download</a>
 </div>


### PR DESCRIPTION
## Summary
- add ability to create new categories via the detail page
- redirect HTML form submissions for new categories
- document the new feature in README

## Testing
- `python -m py_compile loradb/api/__init__.py loradb/agents/indexing_agent.py bulk_import.py migrate_categories.py main.py`
- `find . -name '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_685b1908ef28833399cb387a2974426d