### PR TITLE
Add dynamic 'No Category' support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Detail View
 - **File removal** – delete LoRA files or individual preview images from the interface.
 - **Category management** – organise LoRAs into categories and filter the gallery accordingly.
 - **Remove categories** – unassign a model from a category directly from the detail page.
+- **Find uncategorised models** – a dynamic *No Category* filter lists LoRAs without any category.
 
 ## Project layout
 


### PR DESCRIPTION
## Summary
- list uncategorised LoRAs via a pseudo "No Category" entry
- display "No Category" for models without categories
- document uncategorised filter in README

## Testing
- `python -m py_compile loradb/agents/indexing_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_685c1ed28460833387051f1e71d1724d