### PR TITLE
Add upload wizard for LoRA files

### DIFF
--- a/loradb/agents/uploader_agent.py
+++ b/loradb/agents/uploader_agent.py
@@ -70,6 +70,27 @@ class UploaderAgent:
             self.frontend.refresh_preview_cache(stem)
         return extracted
 
+    def save_preview_files(self, stem: str, files: Iterable) -> List[Path]:
+        """Save preview image ``files`` for the LoRA identified by ``stem``."""
+        extracted: List[Path] = []
+        index = 0
+        for file in files:
+            suffix = Path(file.filename).suffix.lower()
+            if suffix not in {".png", ".jpg", ".jpeg", ".gif"}:
+                continue
+            if index == 0:
+                dest_name = f"{stem}{suffix}"
+            else:
+                dest_name = f"{stem}_{index}{suffix}"
+            dest = self.upload_dir / dest_name
+            with dest.open("wb") as out:
+                shutil.copyfileobj(file.file, out)
+            extracted.append(dest)
+            index += 1
+        if self.frontend:
+            self.frontend.refresh_preview_cache(stem)
+        return extracted
+
     def delete_lora(self, filename: str) -> None:
         """Delete a LoRA file and all associated preview images."""
         path = self.upload_dir / filename

--- a/loradb/static/style.css
+++ b/loradb/static/style.css
@@ -97,3 +97,17 @@ h1 { margin-top: 1rem; font-weight: 600; }
 .metadata-table tr:nth-child(even) {
   background-color: #212529;
 }
+
+/* Drag and drop areas used in the upload wizard */
+.drop-area {
+  border: 2px dashed #6c757d;
+  border-radius: 0.5rem;
+  padding: 2rem;
+  text-align: center;
+  color: #adb5bd;
+  cursor: pointer;
+}
+
+.drop-area.dragover {
+  background-color: rgba(108, 117, 125, 0.2);
+}

--- a/loradb/templates/base.html
+++ b/loradb/templates/base.html
@@ -21,6 +21,7 @@
             <li class="nav-item"><a class="nav-link" href="/grid">Gallery</a></li>
             <li class="nav-item"><a class="nav-link" href="/upload">Upload</a></li>
             <li class="nav-item"><a class="nav-link" href="/upload_previews">Upload Previews</a></li>
+            <li class="nav-item"><a class="nav-link" href="/upload_wizard">Upload Wizard</a></li>
           </ul>
         </div>
       </div>

--- a/loradb/templates/upload_wizard.html
+++ b/loradb/templates/upload_wizard.html
@@ -1,0 +1,56 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Upload Wizard</h1>
+<div id="step1">
+  <h3 class="mb-3">1. Upload safetensors</h3>
+  <div id="drop-safetensors" class="drop-area mb-2">Drag & Drop .safetensors here or click</div>
+  <input id="safetensors-input" type="file" accept=".safetensors" class="d-none">
+  <button id="upload-safetensors" class="btn btn-primary">Upload</button>
+</div>
+<div id="step2" style="display:none;">
+  <h3 class="mb-3">2. Upload previews</h3>
+  <div id="drop-previews" class="drop-area mb-2">Drag & Drop images or ZIP here or click</div>
+  <input id="previews-input" type="file" multiple accept=".png,.jpg,.jpeg,.gif,.zip" class="d-none">
+  <button id="upload-previews" class="btn btn-primary">Upload Previews</button>
+</div>
+<script>
+function setupArea(areaId, inputId) {
+  const area = document.getElementById(areaId);
+  const input = document.getElementById(inputId);
+  area.addEventListener('click', () => input.click());
+  area.addEventListener('dragover', e => { e.preventDefault(); area.classList.add('dragover'); });
+  area.addEventListener('dragleave', () => area.classList.remove('dragover'));
+  area.addEventListener('drop', e => { e.preventDefault(); area.classList.remove('dragover'); input.files = e.dataTransfer.files; });
+}
+setupArea('drop-safetensors', 'safetensors-input');
+setupArea('drop-previews', 'previews-input');
+const uploadBtn1 = document.getElementById('upload-safetensors');
+const uploadBtn2 = document.getElementById('upload-previews');
+const step1 = document.getElementById('step1');
+const step2 = document.getElementById('step2');
+let loraStem = '';
+uploadBtn1.addEventListener('click', async () => {
+  const file = document.getElementById('safetensors-input').files[0];
+  if (!file) return;
+  const fd = new FormData();
+  fd.append('files', file);
+  const resp = await fetch('/upload', { method: 'POST', body: fd });
+  if (resp.ok) {
+    loraStem = file.name.replace(/\.safetensors$/i, '');
+    step1.style.display = 'none';
+    step2.style.display = 'block';
+  }
+});
+uploadBtn2.addEventListener('click', async () => {
+  const files = document.getElementById('previews-input').files;
+  if (!files.length) return;
+  const fd = new FormData();
+  for (const f of files) fd.append('files', f);
+  fd.append('lora', loraStem);
+  const resp = await fetch('/upload_previews', { method: 'POST', body: fd });
+  if (resp.ok) {
+    window.location.href = '/detail/' + loraStem + '.safetensors';
+  }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add helper to save preview images without zips
- allow `/upload_previews` to accept zip or image files
- implement JavaScript upload wizard page
- link new wizard from navigation
- style drag-and-drop areas in CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c42dca37c83338c8c440ea3012a41