### PR TITLE
Improve upload wizard drag-and-drop

### DIFF
--- a/loradb/templates/upload_wizard.html
+++ b/loradb/templates/upload_wizard.html
@@ -4,23 +4,45 @@
 <div id="step1">
   <h3 class="mb-3">1. Upload safetensors</h3>
   <div id="drop-safetensors" class="drop-area mb-2">Drag & Drop .safetensors here or click</div>
+  <div id="safetensors-info" class="text-secondary small mb-2"></div>
   <input id="safetensors-input" type="file" accept=".safetensors" class="d-none">
   <button id="upload-safetensors" class="btn btn-primary">Upload</button>
 </div>
 <div id="step2" style="display:none;">
   <h3 class="mb-3">2. Upload previews</h3>
   <div id="drop-previews" class="drop-area mb-2">Drag & Drop images or ZIP here or click</div>
+  <div id="previews-info" class="text-secondary small mb-2"></div>
   <input id="previews-input" type="file" multiple accept=".png,.jpg,.jpeg,.gif,.zip" class="d-none">
   <button id="upload-previews" class="btn btn-primary">Upload Previews</button>
 </div>
 <script>
+function updateInfo(inputId, files) {
+  const info = document.getElementById(inputId.replace('input', 'info'));
+  if (!info) return;
+  if (!files || files.length === 0) {
+    info.textContent = '';
+  } else if (files.length === 1) {
+    info.textContent = files[0].name;
+  } else {
+    info.textContent = files.length + ' files selected';
+  }
+}
+
 function setupArea(areaId, inputId) {
   const area = document.getElementById(areaId);
   const input = document.getElementById(inputId);
   area.addEventListener('click', () => input.click());
   area.addEventListener('dragover', e => { e.preventDefault(); area.classList.add('dragover'); });
   area.addEventListener('dragleave', () => area.classList.remove('dragover'));
-  area.addEventListener('drop', e => { e.preventDefault(); area.classList.remove('dragover'); input.files = e.dataTransfer.files; });
+  area.addEventListener('drop', e => {
+    e.preventDefault();
+    area.classList.remove('dragover');
+    const dt = new DataTransfer();
+    for (const f of e.dataTransfer.files) dt.items.add(f);
+    input.files = dt.files;
+    updateInfo(inputId, dt.files);
+  });
+  input.addEventListener('change', () => updateInfo(inputId, input.files));
 }
 setupArea('drop-safetensors', 'safetensors-input');
 setupArea('drop-previews', 'previews-input');
@@ -31,7 +53,10 @@ const step2 = document.getElementById('step2');
 let loraStem = '';
 uploadBtn1.addEventListener('click', async () => {
   const file = document.getElementById('safetensors-input').files[0];
-  if (!file) return;
+  if (!file) {
+    alert('Please select a .safetensors file first.');
+    return;
+  }
   const fd = new FormData();
   fd.append('files', file);
   const resp = await fetch('/upload', { method: 'POST', body: fd });
@@ -39,17 +64,25 @@ uploadBtn1.addEventListener('click', async () => {
     loraStem = file.name.replace(/\.safetensors$/i, '');
     step1.style.display = 'none';
     step2.style.display = 'block';
+    updateInfo('safetensors-input', []);
+  } else {
+    alert('Upload failed');
   }
 });
 uploadBtn2.addEventListener('click', async () => {
   const files = document.getElementById('previews-input').files;
-  if (!files.length) return;
+  if (!files.length) {
+    alert('Please select preview images or a ZIP file.');
+    return;
+  }
   const fd = new FormData();
   for (const f of files) fd.append('files', f);
   fd.append('lora', loraStem);
   const resp = await fetch('/upload_previews', { method: 'POST', body: fd });
   if (resp.ok) {
     window.location.href = '/detail/' + loraStem + '.safetensors';
+  } else {
+    alert('Preview upload failed');
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- show selected files in upload wizard
- improve drag-and-drop to use DataTransfer
- alert users if no file was selected or if uploads fail

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c46d6f1d88333a738aeb8e4ac2a96