### PR TITLE
Improve upload wizard with progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,7 @@ After starting the service open [http://localhost:5000](http://localhost:5000) i
 
 ### Upload models
 
-Visit `/upload` and select one or more `.safetensors` files. Uploaded models are stored in `loradb/uploads` and indexed automatically.
-
-### Upload previews
-
-Open `/upload_previews` to send a ZIP archive of preview images. Files named `mylora.png`, `mylora_1.png`, ... will be placed next to `mylora.safetensors`.
+The `/upload_wizard` page lets you upload a LoRA file and its previews in one go. The wizard shows the upload progress for both steps and automatically redirects to the detail page once finished.
 
 ### Browse and search
 

--- a/loradb/templates/base.html
+++ b/loradb/templates/base.html
@@ -19,8 +19,6 @@
         <div class="collapse navbar-collapse" id="navcol">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item"><a class="nav-link" href="/grid">Gallery</a></li>
-            <li class="nav-item"><a class="nav-link" href="/upload">Upload</a></li>
-            <li class="nav-item"><a class="nav-link" href="/upload_previews">Upload Previews</a></li>
             <li class="nav-item"><a class="nav-link" href="/upload_wizard">Upload Wizard</a></li>
           </ul>
         </div>

--- a/loradb/templates/index.html
+++ b/loradb/templates/index.html
@@ -2,8 +2,7 @@
 {% block content %}
 <h1 class="mb-4">LoRA Database</h1>
 <p>
-  <a href="/upload" class="btn btn-success me-2">Upload Files</a>
-  <a href="/upload_previews" class="btn btn-secondary me-2">Upload Previews</a>
+  <a href="/upload_wizard" class="btn btn-success me-2">Upload Models</a>
   <a href="/grid" class="btn btn-primary">View Gallery</a>
 </p>
 {% endblock %}

--- a/loradb/templates/upload_wizard.html
+++ b/loradb/templates/upload_wizard.html
@@ -7,6 +7,9 @@
   <div id="safetensors-info" class="text-secondary small mb-2"></div>
   <input id="safetensors-input" type="file" accept=".safetensors" class="d-none">
   <button id="upload-safetensors" class="btn btn-primary">Upload</button>
+  <div id="safetensors-progress" class="progress mt-3 d-none">
+    <div class="progress-bar" role="progressbar" style="width:0%">0%</div>
+  </div>
 </div>
 <div id="step2" style="display:none;">
   <h3 class="mb-3">2. Upload previews</h3>
@@ -14,6 +17,9 @@
   <div id="previews-info" class="text-secondary small mb-2"></div>
   <input id="previews-input" type="file" multiple accept=".png,.jpg,.jpeg,.gif,.zip" class="d-none">
   <button id="upload-previews" class="btn btn-primary">Upload Previews</button>
+  <div id="previews-progress" class="progress mt-3 d-none">
+    <div class="progress-bar" role="progressbar" style="width:0%">0%</div>
+  </div>
 </div>
 <script>
 function updateInfo(inputId, files) {
@@ -50,7 +56,39 @@ const uploadBtn1 = document.getElementById('upload-safetensors');
 const uploadBtn2 = document.getElementById('upload-previews');
 const step1 = document.getElementById('step1');
 const step2 = document.getElementById('step2');
+const stProgress = document.querySelector('#safetensors-progress .progress-bar');
+const stContainer = document.getElementById('safetensors-progress');
+const prProgress = document.querySelector('#previews-progress .progress-bar');
+const prContainer = document.getElementById('previews-progress');
 let loraStem = '';
+
+function uploadWithProgress(url, fd, bar, container) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', url);
+    container.classList.remove('d-none');
+    bar.style.width = '0%';
+    bar.textContent = '0%';
+    xhr.upload.addEventListener('progress', e => {
+      if (e.lengthComputable) {
+        const pct = Math.round((e.loaded / e.total) * 100);
+        bar.style.width = pct + '%';
+        bar.textContent = pct + '%';
+      }
+    });
+    xhr.onload = () => {
+      container.classList.add('d-none');
+      if (xhr.status >= 200 && xhr.status < 300) resolve(xhr.response);
+      else reject(new Error('upload failed'));
+    };
+    xhr.onerror = () => {
+      container.classList.add('d-none');
+      reject(new Error('upload failed'));
+    };
+    xhr.send(fd);
+  });
+}
+
 uploadBtn1.addEventListener('click', async () => {
   const file = document.getElementById('safetensors-input').files[0];
   if (!file) {
@@ -59,16 +97,17 @@ uploadBtn1.addEventListener('click', async () => {
   }
   const fd = new FormData();
   fd.append('files', file);
-  const resp = await fetch('/upload', { method: 'POST', body: fd });
-  if (resp.ok) {
+  try {
+    await uploadWithProgress('/upload', fd, stProgress, stContainer);
     loraStem = file.name.replace(/\.safetensors$/i, '');
     step1.style.display = 'none';
     step2.style.display = 'block';
     updateInfo('safetensors-input', []);
-  } else {
+  } catch (err) {
     alert('Upload failed');
   }
 });
+
 uploadBtn2.addEventListener('click', async () => {
   const files = document.getElementById('previews-input').files;
   if (!files.length) {
@@ -78,10 +117,10 @@ uploadBtn2.addEventListener('click', async () => {
   const fd = new FormData();
   for (const f of files) fd.append('files', f);
   fd.append('lora', loraStem);
-  const resp = await fetch('/upload_previews', { method: 'POST', body: fd });
-  if (resp.ok) {
+  try {
+    await uploadWithProgress('/upload_previews', fd, prProgress, prContainer);
     window.location.href = '/detail/' + loraStem + '.safetensors';
-  } else {
+  } catch (err) {
     alert('Preview upload failed');
   }
 });


### PR DESCRIPTION
## Summary
- add progress indicators to the upload wizard
- remove the obsolete upload links
- update landing page buttons
- document the new wizard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c4b80137c8333892341202cfd3c49