### PR TITLE
Fix filename handling in upload wizard

### DIFF
--- a/loradb/templates/upload_wizard.html
+++ b/loradb/templates/upload_wizard.html
@@ -61,6 +61,7 @@ const stContainer = document.getElementById('safetensors-progress');
 const prProgress = document.querySelector('#previews-progress .progress-bar');
 const prContainer = document.getElementById('previews-progress');
 let loraStem = '';
+let loraFilename = '';
 
 function uploadWithProgress(url, fd, bar, container) {
   return new Promise((resolve, reject) => {
@@ -98,8 +99,14 @@ uploadBtn1.addEventListener('click', async () => {
   const fd = new FormData();
   fd.append('files', file);
   try {
-    await uploadWithProgress('/upload', fd, stProgress, stContainer);
-    loraStem = file.name.replace(/\.safetensors$/i, '');
+    const resp = await uploadWithProgress('/upload', fd, stProgress, stContainer);
+    try {
+      const result = JSON.parse(resp)[0];
+      loraFilename = result?.filename || file.name;
+    } catch (e) {
+      loraFilename = file.name;
+    }
+    loraStem = loraFilename.replace(/\.safetensors$/i, '');
     step1.style.display = 'none';
     step2.style.display = 'block';
     updateInfo('safetensors-input', []);
@@ -119,7 +126,7 @@ uploadBtn2.addEventListener('click', async () => {
   fd.append('lora', loraStem);
   try {
     await uploadWithProgress('/upload_previews', fd, prProgress, prContainer);
-    window.location.href = '/detail/' + loraStem + '.safetensors';
+    window.location.href = '/detail/' + loraFilename;
   } catch (err) {
     alert('Preview upload failed');
   }


### PR DESCRIPTION
## Summary
- handle server-side file renames in the upload wizard
- redirect to the correct detail page after previews upload

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4df5c7248333adfe79b07b1bff0e