### PR TITLE
Add statistics overview

### DIFF
--- a/loradb/static/style.css
+++ b/loradb/static/style.css
@@ -111,3 +111,10 @@ h1 { margin-top: 1rem; font-weight: 600; }
 .drop-area.dragover {
   background-color: rgba(108, 117, 125, 0.2);
 }
+
+/* Category cloud links on the index page */
+.category-cloud a {
+  text-decoration: none;
+  color: #58a6ff;
+  font-weight: 600;
+}

--- a/loradb/templates/index.html
+++ b/loradb/templates/index.html
@@ -5,4 +5,19 @@
   <a href="/upload_wizard" class="btn btn-success me-2">Upload Models</a>
   <a href="/grid" class="btn btn-primary">View Gallery</a>
 </p>
+<div class="mt-4">
+  <h2 class="h4 mb-3">Statistics</h2>
+  <ul class="list-unstyled">
+    <li><strong>{{ stats.lora_count }}</strong> LoRAs</li>
+    <li><strong>{{ stats.preview_count }}</strong> Preview Images</li>
+    <li><strong>{{ stats.category_count }}</strong> Categories</li>
+  </ul>
+  <div class="category-cloud mt-3">
+    {% for cat in stats.top_categories %}
+    <a href="/grid?q=&category={{ cat.id }}" class="me-2" style="font-size: {{ 0.8 + cat.count * 0.1 }}rem;">
+      {{ cat.name }}
+    </a>
+    {% endfor %}
+  </div>
+</div>
 {% endblock %}

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 
 import config
-from loradb.api import router as api_router
+from loradb.api import router as api_router, indexer
 
 app = FastAPI(title="LoRA Database")
 
@@ -21,7 +21,13 @@ app.include_router(api_router)
 @app.get("/", response_class=HTMLResponse)
 async def index():
     template = env.get_template("index.html")
-    return template.render(title="LoRA Database")
+    stats = {
+        "lora_count": indexer.lora_count(),
+        "preview_count": indexer.preview_count(),
+        "category_count": indexer.category_count(),
+        "top_categories": indexer.top_categories(limit=20),
+    }
+    return template.render(title="LoRA Database", stats=stats)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- show LoRA counts and top categories on the landing page
- expose helpers for counting items in the indexer
- style category cloud

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685c51bf94888333b1c58636a6d24936