### PR TITLE
Improve category cloud layout

### DIFF
--- a/loradb/agents/indexing_agent.py
+++ b/loradb/agents/indexing_agent.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+import math
 
 import sqlite3
 from pathlib import Path
@@ -150,7 +151,22 @@ class IndexingAgent:
             )
         # Sort again to ensure uncategorised slot is in correct position
         categories.sort(key=lambda c: c["count"], reverse=True)
-        return categories[:limit]
+        categories = categories[:limit]
+
+        # Calculate relative font sizes for the category cloud
+        if categories:
+            weights = [math.log(c["count"] + 1) for c in categories]
+            min_w = min(weights)
+            max_w = max(weights)
+            span = max_w - min_w or 1
+            min_size = 0.8
+            max_size = 2.0
+            for c, w in zip(categories, weights):
+                rel = (w - min_w) / span
+                size = min_size + rel * (max_size - min_size)
+                c["size"] = round(size, 2)
+
+        return categories
 
     def add_metadata(self, data: Dict[str, str]) -> None:
         self.conn.execute(

--- a/loradb/static/style.css
+++ b/loradb/static/style.css
@@ -112,7 +112,13 @@ h1 { margin-top: 1rem; font-weight: 600; }
   background-color: rgba(108, 117, 125, 0.2);
 }
 
-/* Category cloud links on the index page */
+/* Category cloud on the index page */
+.category-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  line-height: 1.2;
+}
 .category-cloud a {
   text-decoration: none;
   color: #58a6ff;

--- a/loradb/templates/index.html
+++ b/loradb/templates/index.html
@@ -14,7 +14,7 @@
   </ul>
   <div class="category-cloud mt-3">
     {% for cat in stats.top_categories %}
-    <a href="/grid?q=&category={{ cat.id }}" class="me-2" style="font-size: {{ 0.8 + cat.count * 0.1 }}rem;">
+    <a href="/grid?q=&category={{ cat.id }}" style="font-size: {{ cat.size }}rem;" class="me-2">
       {{ cat.name }}
     </a>
     {% endfor %}


### PR DESCRIPTION
## Summary
- normalize tag cloud font sizes in `top_categories`
- tweak tag cloud layout styles
- render the category cloud with normalized sizes

## Testing
- `python -m py_compile loradb/agents/indexing_agent.py`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685c53ad6fb483338b4bb8b7cae26231