### PR TITLE
Add category admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Guided upload page that first asks for the `.safetensors` file and then its prev
 
 ![grafik](https://github.com/user-attachments/assets/30a14ca7-bd06-4af6-9e10-12a728b07c06)
 
+### Category admin `/category_admin`
+Manage all categories in one place. Create new entries and remove unused ones. A table lists how many LoRAs are assigned to each category.
+
 ## Bulk import
 Use `bulk_import.py` to ingest an existing collection:
 

--- a/loradb/agents/frontend_agent.py
+++ b/loradb/agents/frontend_agent.py
@@ -75,3 +75,8 @@ class FrontendAgent:
         entry.setdefault("metadata", {})
         template = self.env.get_template("detail.html")
         return template.render(title=entry.get("name"), entry=entry, categories=categories or [])
+
+    def render_category_admin(self, categories: List[Dict[str, str]]) -> str:
+        """Render the category administration page."""
+        template = self.env.get_template("category_admin.html")
+        return template.render(title="Category Administration", categories=categories)

--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -119,6 +119,22 @@ async def unassign_category(request: Request, filename: str = Form(...), categor
         return RedirectResponse(url=f'/detail/{filename}', status_code=303)
     return {'status': 'ok'}
 
+
+@router.get('/category_admin', response_class=HTMLResponse)
+async def category_admin():
+    """Display the category administration page."""
+    categories = indexer.list_categories_with_counts()
+    return frontend.render_category_admin(categories)
+
+
+@router.post('/delete_category')
+async def delete_category(request: Request, category_id: int = Form(...)):
+    indexer.delete_category(category_id)
+    if 'text/html' in request.headers.get('accept', ''):
+        referer = request.headers.get('referer', '/category_admin')
+        return RedirectResponse(url=referer, status_code=303)
+    return {'status': 'ok'}
+
 @router.get('/grid', response_class=HTMLResponse)
 async def grid(request: Request):
     query = request.query_params.get('q', '*')

--- a/loradb/templates/base.html
+++ b/loradb/templates/base.html
@@ -20,6 +20,7 @@
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item"><a class="nav-link" href="/grid">Gallery</a></li>
             <li class="nav-item"><a class="nav-link" href="/upload_wizard">Upload Wizard</a></li>
+            <li class="nav-item"><a class="nav-link" href="/category_admin">Categories</a></li>
           </ul>
         </div>
       </div>

--- a/loradb/templates/category_admin.html
+++ b/loradb/templates/category_admin.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Category Administration</h1>
+<form method="post" action="/categories" class="mb-3 d-flex" style="max-width:400px;">
+  <input type="text" name="name" class="form-control me-2" placeholder="New category" required>
+  <button class="btn btn-primary" type="submit">Add</button>
+</form>
+<table class="table table-dark table-striped">
+  <thead>
+    <tr><th>Name</th><th>LoRAs</th><th></th></tr>
+  </thead>
+  <tbody>
+    {% for cat in categories %}
+    <tr>
+      <td>{{ cat.name }}</td>
+      <td>{{ cat.count }}</td>
+      <td>
+        {% if cat.id != 0 %}
+        <form method="post" action="/delete_category" onsubmit="return confirm('Delete category {{ cat.name }}?');">
+          <input type="hidden" name="category_id" value="{{ cat.id }}">
+          <button class="btn btn-sm btn-danger">Delete</button>
+        </form>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add link to new category admin page in navbar
- implement category admin frontend and API
- support listing and deleting categories in indexer
- document the new `/category_admin` page in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d6fb071f483338dd7fad243bb6026