### PR TITLE
Add lora-specific preview uploader

### DIFF
--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -44,9 +44,15 @@ async def upload(request: Request, files: list[UploadFile] = File(...)):
 
 
 @router.get('/upload_previews', response_class=HTMLResponse)
-async def upload_previews_form():
-    """Form for uploading preview zip files."""
-    return frontend.env.get_template('upload_previews.html').render(title='Upload Previews')
+async def upload_previews_form(lora: str | None = None):
+    """Form for uploading preview images or zip files.
+
+    If ``lora`` is provided, the form will target that specific LoRA and allow
+    uploading additional preview images. Otherwise a generic upload form for a
+    preview ZIP is shown.
+    """
+    template = frontend.env.get_template('upload_previews.html')
+    return template.render(title='Upload Previews', lora=lora)
 
 
 @router.post('/upload_previews')

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -41,8 +41,9 @@
   <a class="btn btn-primary" href="/uploads/{{ entry.filename }}" download>Download</a>
 </div>
 <form method="post" action="/delete">
-  <div class="d-flex justify-content-end mb-2">
+  <div class="d-flex justify-content-end mb-2 gap-2">
     <button class="btn btn-danger btn-sm" type="submit">Remove Selected</button>
+    <a class="btn btn-secondary btn-sm" href="/upload_previews?lora={{ entry.filename|replace('.safetensors','') }}">Upload Images</a>
   </div>
   <div class="preview-grid mb-3">
     {% for img in entry.previews %}

--- a/loradb/templates/upload_previews.html
+++ b/loradb/templates/upload_previews.html
@@ -1,10 +1,21 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1 class="mb-4">Upload Preview Zip</h1>
+{% if lora %}
+<h1 class="mb-4">Upload Previews for {{ lora }}</h1>
 <form method="post" action="/upload_previews" enctype="multipart/form-data">
+  <input type="hidden" name="lora" value="{{ lora }}">
   <div class="mb-3">
-    <input class="form-control" type="file" name="file" accept=".zip" required>
+    <input class="form-control" type="file" name="files" multiple accept=".png,.jpg,.jpeg,.gif,.zip" required>
   </div>
   <button class="btn btn-primary" type="submit">Upload</button>
 </form>
+{% else %}
+<h1 class="mb-4">Upload Preview Zip</h1>
+<form method="post" action="/upload_previews" enctype="multipart/form-data">
+  <div class="mb-3">
+    <input class="form-control" type="file" name="files" accept=".zip" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Upload</button>
+</form>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- support optional `lora` parameter on `/upload_previews` page
- show upload form for a specific LoRA when `lora` query string is used
- add `Upload Images` button on detail page linking to that form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e3164c2548333a30f315e321e3fb1