### PR TITLE
Add Docker setup builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/docker_setup/README.md
+++ b/docker_setup/README.md
@@ -1,0 +1,28 @@
+# Docker Setup Builder
+
+This folder contains a helper script to generate a Docker setup for **MyLora**.
+It works on both Windows and Linux by automatically detecting the operating
+system.
+
+Running the script will:
+
+1. Clone the MyLora repository into `./app` if it is not already present.
+2. Create a `Dockerfile` and `docker-compose.yml` inside the cloned directory.
+3. Configure Docker volumes so the SQLite index database and uploaded files are
+   stored outside of the container for easy backup.
+
+## Usage
+
+```bash
+python builder.py [REPO_URL]
+```
+
+The default repository URL points to the main MyLora GitHub repository. After the
+files have been created you can start the service with:
+
+```bash
+cd app
+docker compose up -d
+```
+
+The web interface will be available at `http://localhost:5000`.

--- a/docker_setup/builder.py
+++ b/docker_setup/builder.py
@@ -1,0 +1,74 @@
+import os
+import platform
+import subprocess
+from pathlib import Path
+import shutil
+
+DEFAULT_REPO = "https://github.com/AsaTyr2018/MyLora.git"
+APP_DIR = Path("app")
+
+def run(cmd: list[str]):
+    subprocess.check_call(cmd)
+
+def detect_os() -> str:
+    system = platform.system().lower()
+    if 'windows' in system:
+        return 'windows'
+    return 'linux'
+
+def clone_repo(repo: str) -> Path:
+    if APP_DIR.exists():
+        print(f"Using existing repo in {APP_DIR}")
+        return APP_DIR
+    run(["git", "clone", repo, str(APP_DIR)])
+    return APP_DIR
+
+def create_dockerfile(path: Path):
+    df = path / "Dockerfile"
+    if df.exists():
+        return
+    df.write_text(
+        """
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+EXPOSE 5000
+CMD [\"python\", \"main.py\"]
+"""
+    )
+
+
+def create_compose(path: Path):
+    compose = path / "docker-compose.yml"
+    if compose.exists():
+        return
+    compose.write_text(
+        """
+version: '3'
+services:
+  mylora:
+    build: .
+    ports:
+      - '5000:5000'
+    volumes:
+      - ./loradb/uploads:/app/loradb/uploads
+      - ./loradb/search_index:/app/loradb/search_index
+"""
+    )
+
+def main(repo: str = DEFAULT_REPO):
+    os_type = detect_os()
+    print(f"Detected OS: {os_type}")
+    path = clone_repo(repo)
+    create_dockerfile(path)
+    create_compose(path)
+    print("Docker setup files created. Run 'docker compose up' to start.")
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build Docker setup for MyLora")
+    parser.add_argument("repo", nargs="?", default=DEFAULT_REPO, help="Repository to clone")
+    args = parser.parse_args()
+    main(args.repo)


### PR DESCRIPTION
## Summary
- create cross-platform Docker setup builder in `docker_setup`
- document usage for generating Dockerfile and docker-compose
- ignore Python bytecode files
- remove accidentally committed `__pycache__`

## Testing
- `python -m py_compile docker_setup/builder.py`
- `python -m py_compile main.py docker_setup/builder.py`

------
https://chatgpt.com/codex/tasks/task_e_685fabd1070483339992024d8a7136cc