### PR TITLE
Add Docker builder instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ sudo ./setup.sh uninstall    # remove
 
 The service will be available on [http://{serverip}:5000](http://{serverip}:5000).
 
+### Docker builder
+
+An alternative setup runs MyLora inside Docker. Execute the builder script and
+start the created container:
+
+```bash
+cd docker_setup
+python builder.py
+cd app
+docker compose up -d
+```
+
+To update the container later on, run `python update.py` from the same
+directory.
+
 ## Pages overview
 
 ### Main site `/`


### PR DESCRIPTION
## Summary
- add a Docker builder section to the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685fb8b660c88333af5412731a6686b2