### PR TITLE
Improve plugin enable/disable behavior

### DIFF
--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -215,7 +215,7 @@ async def enable_plugin(request: Request, plugin: str = Form(...)):
 
 @router.post('/disable_plugin')
 async def disable_plugin(request: Request, plugin: str = Form(...)):
-    plugin_manager.disable(plugin)
+    plugin_manager.disable(plugin, request.app)
     if 'text/html' in request.headers.get('accept', ''):
         return RedirectResponse(url='/plugins', status_code=303)
     return {'status': 'disabled', 'plugin': plugin}

--- a/loradb/plugins/manager.py
+++ b/loradb/plugins/manager.py
@@ -1,7 +1,7 @@
 import json
 import importlib.util
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Any
 
 import pluggy
 from fastapi import FastAPI
@@ -30,6 +30,7 @@ class PluginManager:
         self.manager = pluggy.PluginManager(pm_namespace)
         self.manager.add_hookspecs(HookSpecs)
         self.loaded: Dict[str, object] = {}
+        self.loaded_routes: Dict[str, List[Any]] = {}
 
     def _save_status(self) -> None:
         self.status_path.write_text(json.dumps(self.status, indent=2))
@@ -72,15 +73,29 @@ class PluginManager:
         spec.loader.exec_module(mod)
         self.manager.register(mod, plugin_id)
         self.loaded[plugin_id] = mod
+        existing = list(app.router.routes)
         self.manager.hook.setup(app=app)
+        new_routes = [r for r in app.router.routes if r not in existing]
+        self.loaded_routes[plugin_id] = new_routes
+
+    def _unload_plugin(self, plugin_id: str, app: FastAPI | None) -> None:
+        if plugin_id not in self.loaded:
+            return
+        if app is not None:
+            for route in self.loaded_routes.get(plugin_id, []):
+                if route in app.router.routes:
+                    app.router.routes.remove(route)
+        self.manager.unregister(name=plugin_id)
+        self.loaded.pop(plugin_id, None)
+        self.loaded_routes.pop(plugin_id, None)
 
     def enable(self, plugin_id: str, app: FastAPI) -> None:
         self.status[plugin_id] = True
         self._save_status()
         self._load_plugin(plugin_id, app)
 
-    def disable(self, plugin_id: str) -> None:
+    def disable(self, plugin_id: str, app: FastAPI | None = None) -> None:
         self.status[plugin_id] = False
         self._save_status()
-        # No unloading for simplicity
+        self._unload_plugin(plugin_id, app)
 


### PR DESCRIPTION
## Summary
- allow unloading plugins at runtime
- track routes per plugin and remove them when disabled
- pass `app` instance to the disable endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc5296e188333ad7c56451c98a5ff