### PR TITLE
Fix plugin cleanup

### DIFF
--- a/demo-plugins/extream_title/plugin.py
+++ b/demo-plugins/extream_title/plugin.py
@@ -1,8 +1,11 @@
 from loradb.plugins.manager import hookimpl
 from loradb.api import frontend
 
+original_render_grid = None
+
 @hookimpl
 def setup(app):
+    global original_render_grid
     original_render_grid = frontend.render_grid
 
     def render_grid_with_extream(*args, **kwargs):
@@ -10,3 +13,11 @@ def setup(app):
         return html.replace('LoRA Gallery', 'LoRA Gallery - Extream!')
 
     frontend.render_grid = render_grid_with_extream
+
+
+@hookimpl
+def teardown(app):
+    global original_render_grid
+    if original_render_grid:
+        frontend.render_grid = original_render_grid
+        original_render_grid = None


### PR DESCRIPTION
## Summary
- support plugin teardown so disabled plugins revert changes
- restore original frontend functions in the demo plugin

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685fc6cb0c948333a11721c1576dda4c