### PR TITLE
Persist plugin state in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Manage all categories in one place. Create new entries and remove unused ones. A
 ![grafik](https://github.com/user-attachments/assets/28cfaab7-c6fc-471e-8ef1-87a21fcae47f)
 
 ### Plugin admin `/plugins`
-Enable or disable installed plugins. New plugins placed in the `plugins/` directory are discovered automatically and can be activated from here.
+Toggle installed plugins on or off. The selected state is stored in the database and is applied when the server is refreshed. Use the **Refresh Server** button on this page after changing any plugin state.
 
 ## Bulk import
 Use `bulk_import.py` to ingest an existing collection:

--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -207,7 +207,7 @@ async def plugin_admin():
 
 @router.post('/enable_plugin')
 async def enable_plugin(request: Request, plugin: str = Form(...)):
-    plugin_manager.enable(plugin, request.app)
+    plugin_manager.enable(plugin)
     if 'text/html' in request.headers.get('accept', ''):
         return RedirectResponse(url='/plugins', status_code=303)
     return {'status': 'enabled', 'plugin': plugin}
@@ -215,7 +215,16 @@ async def enable_plugin(request: Request, plugin: str = Form(...)):
 
 @router.post('/disable_plugin')
 async def disable_plugin(request: Request, plugin: str = Form(...)):
-    plugin_manager.disable(plugin, request.app)
+    plugin_manager.disable(plugin)
     if 'text/html' in request.headers.get('accept', ''):
         return RedirectResponse(url='/plugins', status_code=303)
     return {'status': 'disabled', 'plugin': plugin}
+
+
+@router.post('/refresh_server')
+async def refresh_server(request: Request):
+    """Restart the application process."""
+    request.app.state._refreshing = True
+    import os
+    os._exit(0)
+

--- a/loradb/plugins/db.py
+++ b/loradb/plugins/db.py
@@ -1,0 +1,29 @@
+import sqlite3
+from pathlib import Path
+from typing import Dict
+
+
+class PluginStateDB:
+    """Persist plugin enabled state using SQLite."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS plugin_state (id TEXT PRIMARY KEY, enabled INTEGER)"
+        )
+        self.conn.commit()
+
+    def get_all(self) -> Dict[str, bool]:
+        cur = self.conn.cursor()
+        rows = cur.execute("SELECT id, enabled FROM plugin_state").fetchall()
+        return {r[0]: bool(r[1]) for r in rows}
+
+    def set_state(self, plugin_id: str, enabled: bool) -> None:
+        self.conn.execute(
+            "INSERT INTO plugin_state (id, enabled) VALUES (?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET enabled=excluded.enabled",
+            (plugin_id, int(enabled)),
+        )
+        self.conn.commit()

--- a/loradb/templates/plugin_admin.html
+++ b/loradb/templates/plugin_admin.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">Plugin Administration</h1>
+<form method="post" action="/refresh_server" class="mb-3">
+  <button class="btn btn-primary">Refresh Server</button>
+</form>
 <table class="table table-dark table-striped">
   <thead>
     <tr><th>Name</th><th>Description</th><th>Version</th><th></th></tr>
@@ -12,17 +15,12 @@
       <td>{{ p.description }}</td>
       <td>{{ p.version }}</td>
       <td>
-        {% if p.enabled %}
-        <form method="post" action="/disable_plugin" class="d-inline">
+        <form method="post" action="{{ '/enable_plugin' if not p.enabled else '/disable_plugin' }}" class="d-inline">
           <input type="hidden" name="plugin" value="{{ p.id }}">
-          <button class="btn btn-sm btn-warning">Disable</button>
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" name="state" onchange="this.form.action=this.checked?'/enable_plugin':'/disable_plugin'; this.form.submit();" {% if p.enabled %}checked{% endif %}>
+          </div>
         </form>
-        {% else %}
-        <form method="post" action="/enable_plugin" class="d-inline">
-          <input type="hidden" name="plugin" value="{{ p.id }}">
-          <button class="btn btn-sm btn-success">Enable</button>
-        </form>
-        {% endif %}
       </td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- store plugin enabled state in a sqlite database
- modify plugin manager to read/write this state
- add Refresh Server endpoint and button
- require restart after toggling plugins

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fc86734a48333a5b6e2393249daf2