### PR TITLE
Use uvicorn's shutdown for plugin refresh

### DIFF
--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -223,8 +223,13 @@ async def disable_plugin(request: Request, plugin: str = Form(...)):
 
 @router.post('/refresh_server')
 async def refresh_server(request: Request):
-    """Restart the application process."""
+    """Restart the application process gracefully."""
     request.app.state._refreshing = True
-    import os
-    os._exit(0)
+    server = getattr(request.app.state, "uvicorn_server", None)
+    if server is not None:
+        import signal
+        server.handle_exit(signal.SIGINT, None)
+    else:
+        import os
+        os._exit(0)
 

--- a/main.py
+++ b/main.py
@@ -33,4 +33,7 @@ async def index():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=5000)
+    config = uvicorn.Config(app, host="0.0.0.0", port=5000)
+    server = uvicorn.Server(config)
+    app.state.uvicorn_server = server
+    server.run()


### PR DESCRIPTION
## Summary
- ensure server shutdown uses uvicorn
- store uvicorn `Server` instance for reuse

## Testing
- `python -m py_compile main.py loradb/api/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685fcc55ad208333acc73e8356f77503