### PR TITLE
Add watchdog refresh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Manage all categories in one place. Create new entries and remove unused ones. A
 ![grafik](https://github.com/user-attachments/assets/28cfaab7-c6fc-471e-8ef1-87a21fcae47f)
 
 ### Plugin admin `/plugins`
-Toggle installed plugins on or off. The selected state is stored in the database and is applied when the server is refreshed. Use the **Refresh Server** button on this page after changing any plugin state.
+Toggle installed plugins on or off. The selected state is stored in the database and is applied when the server is refreshed. The refresh action now calls `refresh_server.sh`, which restarts the `mylora` service via systemd. Use the **Refresh Server** button after changing plugin state.
 
 ## Bulk import
 Use `bulk_import.py` to ingest an existing collection:

--- a/config.py
+++ b/config.py
@@ -17,3 +17,6 @@ TEMPLATE_DIR = BASE_DIR / "loradb" / "templates"
 
 # Directory containing plugin folders
 PLUGINS_DIR = BASE_DIR / "plugins"
+
+# Path to the watchdog script used to restart the server
+REFRESH_SCRIPT = BASE_DIR / "refresh_server.sh"

--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, UploadFile, File, Request, Form
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pathlib import Path
 import random
+import subprocess
 
 import config
 
@@ -223,13 +224,11 @@ async def disable_plugin(request: Request, plugin: str = Form(...)):
 
 @router.post('/refresh_server')
 async def refresh_server(request: Request):
-    """Restart the application process gracefully."""
-    request.app.state._refreshing = True
-    server = getattr(request.app.state, "uvicorn_server", None)
-    if server is not None:
-        import signal
-        server.handle_exit(signal.SIGINT, None)
-    else:
-        import os
-        os._exit(0)
+    """Restart the server using the external watchdog script."""
+    script = config.REFRESH_SCRIPT
+    try:
+        subprocess.Popen([str(script)])
+    except Exception:
+        return {"error": "failed to execute watchdog"}
+    return {"status": "restarting"}
 

--- a/refresh_server.sh
+++ b/refresh_server.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Restart the MyLora service via systemd.
+set -e
+SERVICE="mylora.service"
+# Stop service if running
+if systemctl is-active --quiet "$SERVICE"; then
+    systemctl stop "$SERVICE"
+fi
+# Start service
+systemctl start "$SERVICE"


### PR DESCRIPTION
## Summary
- add a `refresh_server.sh` watchdog script
- call watchdog from refresh endpoint
- reference new script in README
- expose script path in config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n refresh_server.sh`


------
https://chatgpt.com/codex/tasks/task_e_685fceb448d08333b3bb0ea3a266dec8