### PR TITLE
Update restart script for non-systemd usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Manage all categories in one place. Create new entries and remove unused ones. A
 ![grafik](https://github.com/user-attachments/assets/28cfaab7-c6fc-471e-8ef1-87a21fcae47f)
 
 ### Plugin admin `/plugins`
-Toggle installed plugins on or off. The selected state is stored in the database and is applied when the server is refreshed. The refresh action now calls `refresh_server.sh`, which restarts the `mylora` service via systemd. Use the **Refresh Server** button after changing plugin state.
+Toggle installed plugins on or off. The selected state is stored in the database and is applied when the server is refreshed. The refresh action now calls `refresh_server.sh`, which restarts the application by killing the running process and launching `main.py` again. Use the **Refresh Server** button after changing plugin state.
 
 ## Bulk import
 Use `bulk_import.py` to ingest an existing collection:

--- a/refresh_server.sh
+++ b/refresh_server.sh
@@ -1,10 +1,25 @@
 #!/usr/bin/env bash
-# Restart the MyLora service via systemd.
+# Restart the MyLora application by killing the running process and
+# starting ``main.py`` again. This works when the server was launched
+# manually without a systemd service.
+
 set -e
-SERVICE="mylora.service"
-# Stop service if running
-if systemctl is-active --quiet "$SERVICE"; then
-    systemctl stop "$SERVICE"
-fi
-# Start service
-systemctl start "$SERVICE"
+
+# Resolve the directory of this script so we can locate ``main.py`` even
+# when called from elsewhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_MAIN="$SCRIPT_DIR/main.py"
+PYTHON_BIN="${PYTHON:-python3}"
+
+# Find running main.py processes and terminate them. ``pkill`` returns a
+# non-zero exit status if no process matched, so ignore failures.
+pkill -f "$APP_MAIN" 2>/dev/null || true
+
+# Give the processes a moment to shut down cleanly.
+sleep 2
+
+# Restart the application in the background. ``nohup`` ensures the
+# process keeps running if the calling shell exits.
+nohup "$PYTHON_BIN" "$APP_MAIN" >/dev/null 2>&1 &
+
+echo "MyLora restarted"


### PR DESCRIPTION
## Summary
- restart script now finds and kills `main.py` processes
- refresh the README to reflect new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fd51dd6508333bb1e8ecf38519eb1