### PR TITLE
Add restart page with auto redirect

### DIFF
--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -229,6 +229,13 @@ async def refresh_server(request: Request):
     try:
         subprocess.Popen([str(script)])
     except Exception:
+        if 'text/html' in request.headers.get('accept', ''):
+            template = frontend.env.get_template('restart.html')
+            return template.render(title='Restarting')
         return {"error": "failed to execute watchdog"}
+
+    if 'text/html' in request.headers.get('accept', ''):
+        template = frontend.env.get_template('restart.html')
+        return template.render(title='Restarting')
     return {"status": "restarting"}
 

--- a/loradb/templates/restart.html
+++ b/loradb/templates/restart.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="d-flex flex-column align-items-center mt-5">
+  <h1 class="display-4 mb-3">Reloading the Universe...</h1>
+  <p class="lead">Hold on tight while everything realigns.</p>
+  <div class="spinner-border text-info mt-4" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>
+<script>
+  setTimeout(function(){ window.location.href = '/'; }, 5000);
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- show a stylish intermediate page when refreshing the server
- auto-redirect back to the index after 5 seconds

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fd63b04508333939e91d75eb704ca