### PR TITLE
Fix plugin unloading

### DIFF
--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -209,7 +209,7 @@ async def plugin_admin():
 
 @router.post('/enable_plugin')
 async def enable_plugin(request: Request, plugin: str = Form(...)):
-    plugin_manager.enable(plugin)
+    plugin_manager.enable(plugin, request.app)
     if 'text/html' in request.headers.get('accept', ''):
         return RedirectResponse(url='/plugins', status_code=303)
     return {'status': 'enabled', 'plugin': plugin}
@@ -217,7 +217,7 @@ async def enable_plugin(request: Request, plugin: str = Form(...)):
 
 @router.post('/disable_plugin')
 async def disable_plugin(request: Request, plugin: str = Form(...)):
-    plugin_manager.disable(plugin)
+    plugin_manager.disable(plugin, request.app)
     if 'text/html' in request.headers.get('accept', ''):
         return RedirectResponse(url='/plugins', status_code=303)
     return {'status': 'disabled', 'plugin': plugin}

--- a/loradb/plugins/manager.py
+++ b/loradb/plugins/manager.py
@@ -100,11 +100,17 @@ class PluginManager:
         self.loaded.pop(plugin_id, None)
         self.loaded_routes.pop(plugin_id, None)
 
-    def enable(self, plugin_id: str) -> None:
+    def enable(self, plugin_id: str, app: FastAPI | None = None) -> None:
+        """Enable ``plugin_id`` and load it immediately if ``app`` is provided."""
         self.status[plugin_id] = True
         self._save_status()
+        if app is not None:
+            self._load_plugin(plugin_id, app)
 
-    def disable(self, plugin_id: str) -> None:
+    def disable(self, plugin_id: str, app: FastAPI | None = None) -> None:
+        """Disable ``plugin_id`` and unload it from ``app`` if loaded."""
         self.status[plugin_id] = False
         self._save_status()
+        if app is not None:
+            self._unload_plugin(plugin_id, app)
 


### PR DESCRIPTION
## Summary
- allow dynamic plugin load/unload by passing the app object
- unload plugins when disabled via API

## Testing
- `python -m py_compile loradb/plugins/manager.py loradb/api/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_685fdcd0bf008333a631897209468f6f