### PR TITLE
Fix preview assignment collision

### DIFF
--- a/tests/test_preview_assignment.py
+++ b/tests/test_preview_assignment.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from loradb.agents.frontend_agent import FrontendAgent
+
+
+def test_preview_filtering(tmp_path):
+    # Create some preview files for two different LoRAs
+    (tmp_path / "Mizuki.png").write_text("a")
+    (tmp_path / "Mizuki_18.png").write_text("a")
+    (tmp_path / "Mizuki_Furui_SDXL_10.png").write_text("a")
+
+    agent = FrontendAgent(tmp_path, Path("loradb/templates"))
+    previews = agent._find_previews("Mizuki")
+
+    assert "/uploads/Mizuki.png" in previews
+    assert "/uploads/Mizuki_18.png" in previews
+    assert "/uploads/Mizuki_Furui_SDXL_10.png" not in previews
+


### PR DESCRIPTION
## Summary
- avoid wildcard matches when locating preview images
- add regression test for preview filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866af1cc4388333ac1021a99c61774d