### PR TITLE
Add bulk category assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Link -> https://www.turtlesai.com/en/pages-2946/mylora-intelligent-and-comprehen
 - **Automatic metadata extraction** – tags, dimension and other information are parsed from the model files.
 - **Searchable gallery** – browse all models, filter by tag or category and download directly.
 - **Category management** – create and assign categories with just a few clicks.
+- **Bulk category assignment** – select multiple LoRAs in the gallery and add them to a category.
 - **Local migration** – scripts are included to import existing collections or migrate old category files.
 - **Responsive design** – works great on desktop and mobile.
 

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -10,6 +10,7 @@ This guide describes all remote API endpoints exposed by MyLora. Replace
 | `GET`  | `/categories` | List existing categories |
 | `POST` | `/categories` | Create a new category |
 | `POST` | `/assign_category` | Assign a LoRA to a category |
+| `POST` | `/assign_categories` | Assign multiple LoRAs to a category |
 | `POST` | `/unassign_category` | Remove a LoRA from a category |
 | `POST` | `/upload` | Upload one or more `.safetensors` files |
 | `POST` | `/upload_previews` | Upload preview images or a preview zip |
@@ -143,7 +144,30 @@ curl -X POST -F "filename=awesome_lora.safetensors" -F "category_id=1" \
 {"status": "ok"}
 ```
 
-## 6. `/unassign_category` (POST)
+## 6. `/assign_categories` (POST)
+
+Assign multiple LoRA files to a category.
+
+**Parameters**
+
+- `files`: one or more LoRA filenames
+- `category_id`: existing category ID
+- `new_category`: optional name to create
+
+**Example call**
+
+```bash
+curl -X POST -F "files=a.safetensors" -F "files=b.safetensors" \
+  -F "category_id=1" http://{serverip}:5000/assign_categories
+```
+
+**Example response**
+
+```json
+{"status": "ok"}
+```
+
+## 7. `/unassign_category` (POST)
 
 Remove a LoRA file from the given category.
 
@@ -165,7 +189,7 @@ curl -X POST -F "filename=awesome_lora.safetensors" -F "category_id=1" \
 {"status": "ok"}
 ```
 
-## 7. `/upload` (POST)
+## 8. `/upload` (POST)
 
 Upload one or more `.safetensors` files. The request must be a multipart form
 with `files` as the field name.
@@ -191,7 +215,7 @@ curl -X POST -F "files=@awesome_lora.safetensors" \
 ]
 ```
 
-## 8. `/upload_previews` (POST)
+## 9. `/upload_previews` (POST)
 
 Upload preview images. Send the images as the multipart `files` field. You can
 also upload a ZIP archive containing previews.
@@ -208,7 +232,7 @@ curl -X POST -F "files=@previews.zip" http://{serverip}:5000/upload_previews
 {"status": "ok"}
 ```
 
-## 9. `/delete_category` (POST)
+## 10. `/delete_category` (POST)
 
 Delete a category by its ID.
 
@@ -228,7 +252,7 @@ curl -X POST -F "category_id=3" http://{serverip}:5000/delete_category
 {"status": "ok"}
 ```
 
-## 10. `/delete` (POST)
+## 11. `/delete` (POST)
 
 Delete LoRA or preview files. Provide one or more `files` values as form data.
 

--- a/loradb/agents/frontend_agent.py
+++ b/loradb/agents/frontend_agent.py
@@ -81,3 +81,8 @@ class FrontendAgent:
         """Render the category administration page."""
         template = self.env.get_template("category_admin.html")
         return template.render(title="Category Administration", categories=categories)
+
+    def render_bulk_assign(self, files: List[str], categories: List[Dict[str, str]]) -> str:
+        """Render form to assign multiple LoRAs to a category."""
+        template = self.env.get_template("bulk_assign.html")
+        return template.render(title="Add to Category", files=files, categories=categories)

--- a/loradb/templates/bulk_assign.html
+++ b/loradb/templates/bulk_assign.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Add to Category</h1>
+<form method="post" action="/assign_categories">
+  {% for f in files %}
+  <input type="hidden" name="files" value="{{ f }}">
+  {% endfor %}
+  <div class="mb-3" style="max-width:300px;">
+    <label class="form-label">Select existing Category</label>
+    <select class="form-select" name="category_id">
+      {% for cat in categories %}
+      <option value="{{ cat.id }}">{{ cat.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3" style="max-width:300px;">
+    <label class="form-label">Create new Category</label>
+    <input type="text" class="form-control" name="new_category" placeholder="New category">
+  </div>
+  <button class="btn btn-primary" type="submit">Apply</button>
+</form>
+{% endblock %}

--- a/loradb/templates/grid.html
+++ b/loradb/templates/grid.html
@@ -18,8 +18,9 @@
   </div>
 </form>
 <form method="post" action="/delete">
-  <div class="d-flex justify-content-end mb-2">
+  <div class="d-flex justify-content-end mb-2 gap-2">
     <button class="btn btn-danger btn-sm" type="submit">Remove Selected</button>
+    <button class="btn btn-secondary btn-sm" type="submit" formaction="/bulk_assign" formmethod="post">Add to Category</button>
   </div>
   <div class="gallery-grid" id="gallery">
     {% for entry in entries %}

--- a/tests/test_redirect_logic.py
+++ b/tests/test_redirect_logic.py
@@ -14,6 +14,7 @@ def setup_module(module):
     # Stub indexer methods to avoid database usage
     api.indexer.assign_category = lambda filename, cid: None
     api.indexer.unassign_category = lambda filename, cid: None
+    api.indexer.create_category = lambda name: 1
 
 def test_assign_category_valid_redirect():
     response = client.post(
@@ -42,3 +43,14 @@ def test_unassign_category_invalid_filename():
         follow_redirects=False,
     )
     assert response.status_code == 400
+
+
+def test_assign_categories_redirect():
+    response = client.post(
+        "/assign_categories",
+        data={"files": ["a.safetensors", "b.safetensors"], "category_id": "1"},
+        headers={"accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "/grid"


### PR DESCRIPTION
## 📄 Description
- add button in gallery to assign multiple LoRAs to a category
- implement bulk assignment form and API endpoints
- document new `/assign_categories` endpoint
- update tests and README

## 🧪 Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866b36b8ab08333b81b1bea74704df9