### PR TITLE
Implement read-only role for regular users

### DIFF
--- a/loradb/templates/access_denied.html
+++ b/loradb/templates/access_denied.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Access Denied</h1>
+<p>You do not have permission to view this page.</p>
+<a class="btn btn-primary" href="/">Back to Home</a>
+{% endblock %}

--- a/loradb/templates/base.html
+++ b/loradb/templates/base.html
@@ -19,7 +19,9 @@
         <div class="collapse navbar-collapse" id="navcol">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item"><a class="nav-link" href="/grid">Gallery</a></li>
+            {% if user and user.role == 'admin' %}
             <li class="nav-item"><a class="nav-link" href="/upload_wizard">Upload Wizard</a></li>
+            {% endif %}
             <li class="nav-item"><a class="nav-link" href="/category_admin">Categories</a></li>
             {% if user and user.role == 'admin' %}
             <li class="nav-item"><a class="nav-link" href="/admin/users">Users</a></li>

--- a/loradb/templates/category_admin.html
+++ b/loradb/templates/category_admin.html
@@ -1,19 +1,26 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">Category Administration</h1>
+{% if user and user.role == 'admin' %}
 <form method="post" action="/categories" class="mb-3 d-flex" style="max-width:400px;">
   <input type="text" name="name" class="form-control me-2" placeholder="New category" required>
   <button class="btn btn-primary" type="submit">Add</button>
 </form>
+{% endif %}
 <table class="table table-dark table-striped">
   <thead>
-    <tr><th>Name</th><th>LoRAs</th><th></th></tr>
+    <tr>
+      <th>Name</th>
+      <th>LoRAs</th>
+      {% if user and user.role == 'admin' %}<th></th>{% endif %}
+    </tr>
   </thead>
   <tbody>
     {% for cat in categories %}
     <tr>
       <td>{{ cat.name }}</td>
       <td>{{ cat.count }}</td>
+      {% if user and user.role == 'admin' %}
       <td>
         {% if cat.id != 0 %}
         <form method="post" action="/delete_category" onsubmit="return confirm('Delete category {{ cat.name }}?');">
@@ -22,6 +29,7 @@
         </form>
         {% endif %}
       </td>
+      {% endif %}
     </tr>
     {% endfor %}
   </tbody>

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -7,11 +7,13 @@
     {% for cat in entry.categories %}
     <span class="badge bg-secondary me-1 d-inline-flex align-items-center">
       {{ cat.name }}
+      {% if user and user.role == 'admin' %}
       <form method="post" action="/unassign_category" class="ms-1 d-inline">
         <input type="hidden" name="filename" value="{{ entry.filename }}">
         <input type="hidden" name="category_id" value="{{ cat.id }}">
         <button type="submit" class="btn-close btn-close-white btn-sm" style="float:none"></button>
       </form>
+      {% endif %}
     </span>
     {% endfor %}
   {% else %}
@@ -19,27 +21,30 @@
   {% endif %}
 </div>
   <div class="d-flex align-items-start mb-3 gap-2">
-    {% if categories %}
-    <form method="post" action="/assign_category" style="max-width: 300px;">
-      <input type="hidden" name="filename" value="{{ entry.filename }}">
-      <div class="input-group">
-        <select class="form-select" name="category_id">
-          {% for cat in categories %}
-          <option value="{{ cat.id }}">{{ cat.name }}</option>
-          {% endfor %}
-        </select>
-        <button class="btn btn-outline-primary" type="submit">Add</button>
-      </div>
-    </form>
+    {% if user and user.role == 'admin' %}
+      {% if categories %}
+      <form method="post" action="/assign_category" style="max-width: 300px;">
+        <input type="hidden" name="filename" value="{{ entry.filename }}">
+        <div class="input-group">
+          <select class="form-select" name="category_id">
+            {% for cat in categories %}
+            <option value="{{ cat.id }}">{{ cat.name }}</option>
+            {% endfor %}
+          </select>
+          <button class="btn btn-outline-primary" type="submit">Add</button>
+        </div>
+      </form>
+      {% endif %}
+      <form method="post" action="/categories" style="max-width: 300px;">
+        <div class="input-group">
+          <input type="text" class="form-control" name="name" placeholder="New category">
+          <button class="btn btn-outline-secondary" type="submit">Create</button>
+        </div>
+      </form>
     {% endif %}
-    <form method="post" action="/categories" style="max-width: 300px;">
-      <div class="input-group">
-        <input type="text" class="form-control" name="name" placeholder="New category">
-        <button class="btn btn-outline-secondary" type="submit">Create</button>
-      </div>
-    </form>
-  <a class="btn btn-primary" href="/uploads/{{ entry.filename }}" download>Download</a>
+    <a class="btn btn-primary" href="/uploads/{{ entry.filename }}" download>Download</a>
 </div>
+{% if user and user.role == 'admin' %}
 <form method="post" action="/delete">
   <div class="d-flex justify-content-end mb-2 gap-2">
     <button class="btn btn-danger btn-sm" type="submit">Remove Selected</button>
@@ -54,6 +59,15 @@
     {% endfor %}
   </div>
 </form>
+{% else %}
+<div class="preview-grid mb-3">
+  {% for img in entry.previews %}
+  <div class="position-relative">
+    <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
 <div class="table-responsive">
   <table class="table table-dark table-striped metadata-table">
     <tbody>

--- a/loradb/templates/grid.html
+++ b/loradb/templates/grid.html
@@ -18,17 +18,21 @@
   </div>
 </form>
 <form method="post" action="/delete">
+  {% if user and user.role == 'admin' %}
   <div class="d-flex justify-content-end mb-2 gap-2">
     <button class="btn btn-danger btn-sm" type="submit">Remove Selected</button>
     <button class="btn btn-secondary btn-sm" type="submit" formaction="/bulk_assign" formmethod="post">Add to Category</button>
   </div>
+  {% endif %}
   <div class="gallery-grid" id="gallery">
     {% for entry in entries %}
     <div class="gallery-item position-relative">
       {% if entry.preview_url %}
       <img src="{{ entry.preview_url }}" alt="preview">
       {% endif %}
+      {% if user and user.role == 'admin' %}
       <input class="form-check-input position-absolute m-2 top-0 end-0" type="checkbox" name="files" value="{{ entry.filename }}">
+      {% endif %}
       <div class="title-overlay">
         <a href="/detail/{{ entry.filename }}" class="stretched-link text-light text-decoration-none">{{ entry.name or entry.filename }}</a>
         {% if entry.categories %}
@@ -49,6 +53,7 @@ const limit = {{ limit }};
 let offset = {{ entries|length }};
 const query = "{{ query }}";
 const category = "{{ selected_category }}";
+const isAdmin = {{ 'true' if user and user.role == 'admin' else 'false' }};
 let loading = false;
 
 async function loadMore() {
@@ -72,12 +77,14 @@ async function loadMore() {
       img.alt = 'preview';
       item.appendChild(img);
     }
-    const cb = document.createElement('input');
-    cb.className = 'form-check-input position-absolute m-2 top-0 end-0';
-    cb.type = 'checkbox';
-    cb.name = 'files';
-    cb.value = entry.filename;
-    item.appendChild(cb);
+    if (isAdmin) {
+      const cb = document.createElement('input');
+      cb.className = 'form-check-input position-absolute m-2 top-0 end-0';
+      cb.type = 'checkbox';
+      cb.name = 'files';
+      cb.value = entry.filename;
+      item.appendChild(cb);
+    }
     const overlay = document.createElement('div');
     overlay.className = 'title-overlay';
     const link = document.createElement('a');

--- a/main.py
+++ b/main.py
@@ -52,13 +52,13 @@ async def auth_middleware(request: Request, call_next):
         "/unassign_category",
         "/assign_categories",
         "/bulk_assign",
-        "/category_admin",
         "/delete_category",
         "/delete",
         "/admin/users",
     ]
     if any(path.startswith(p) for p in admin_paths) and user.get("role") != "admin":
-        return HTMLResponse("Forbidden", status_code=403)
+        template = env.get_template("access_denied.html")
+        return HTMLResponse(template.render(title="Access Denied", user=user), status_code=403)
     return await call_next(request)
 
 


### PR DESCRIPTION
## Summary
- add an access denied page
- show `Upload Wizard` link only to admins
- hide admin-only actions in gallery, detail and category pages
- return the new access denied template from middleware

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ccdbd2d883338a057c3a88ff4205