### PR TITLE
Add Model Showcase for guest access

### DIFF
--- a/loradb/agents/frontend_agent.py
+++ b/loradb/agents/frontend_agent.py
@@ -71,6 +71,17 @@ class FrontendAgent:
             user=user,
         )
 
+    def render_showcase(
+        self, entries: List[Dict[str, str]], user: Dict[str, str] | None = None
+    ) -> str:
+        """Render the public showcase grid."""
+        for e in entries:
+            stem = Path(e.get("filename", "")).stem
+            previews = self._find_previews(stem)
+            e["preview_url"] = random.choice(previews) if previews else None
+        template = self.env.get_template("showcase.html")
+        return template.render(title="Model Showcase", entries=entries, user=user)
+
     def render_detail(
         self,
         entry: Dict[str, str],

--- a/loradb/agents/indexing_agent.py
+++ b/loradb/agents/indexing_agent.py
@@ -19,7 +19,7 @@ class IndexingAgent:
     def __init__(self, db_path: Path | None = None) -> None:
         self.db_path = Path(db_path or "loradb/search_index/index.db")
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         recreated = self._ensure_table()
         if recreated or self._is_index_empty():
             self.reindex_all()

--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -121,6 +121,14 @@ async def grid_data(
     return entries
 
 
+@router.get("/showcase", response_class=HTMLResponse)
+async def showcase(request: Request):
+    """Public showcase page listing models in the "Public viewing" category."""
+    public_id = indexer.create_category("Public viewing")
+    entries = indexer.search_by_category(public_id, limit=100)
+    return frontend.render_showcase(entries, user=request.state.user)
+
+
 @router.get("/categories")
 async def list_categories():
     return indexer.list_categories()

--- a/loradb/templates/base.html
+++ b/loradb/templates/base.html
@@ -18,17 +18,18 @@
         </button>
         <div class="collapse navbar-collapse" id="navcol">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="/showcase">Model Showcase</a></li>
+            {% if user and user.role != 'guest' %}
             <li class="nav-item"><a class="nav-link" href="/grid">Gallery</a></li>
-            {% if user and user.role == 'admin' %}
-            <li class="nav-item"><a class="nav-link" href="/upload_wizard">Upload Wizard</a></li>
-            {% endif %}
             <li class="nav-item"><a class="nav-link" href="/category_admin">Categories</a></li>
-            {% if user and user.role == 'admin' %}
+            {% if user.role == 'admin' %}
+            <li class="nav-item"><a class="nav-link" href="/upload_wizard">Upload Wizard</a></li>
             <li class="nav-item"><a class="nav-link" href="/admin/users">Users</a></li>
+            {% endif %}
             {% endif %}
           </ul>
           <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-            {% if user %}
+            {% if user and user.role != 'guest' %}
             <li class="nav-item"><span class="navbar-text me-2">{{ user.username }}</span></li>
             <li class="nav-item"><a class="nav-link" href="/logout">Logout</a></li>
             {% else %}

--- a/loradb/templates/showcase.html
+++ b/loradb/templates/showcase.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Model Showcase</h1>
+<div class="gallery-grid">
+  {% for entry in entries %}
+  <div class="gallery-item">
+    {% if entry.preview_url %}
+    <img src="{{ entry.preview_url }}" alt="preview">
+    {% endif %}
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/main.py
+++ b/main.py
@@ -31,18 +31,21 @@ async def auth_middleware(request: Request, call_next):
     user = None
     if request.session.get("user_id"):
         user = auth.get_user_by_id(request.session["user_id"])
+    if not user:
+        user = {"username": "guest", "role": "guest"}
     request.state.user = user
     if os.environ.get("TESTING"):
         return await call_next(request)
     path = request.url.path
     if (
-        path in {"/login", "/logout"}
-        or path.startswith("/static")
+        path.startswith("/static")
         or path.startswith("/uploads")
+        or path.startswith("/login")
+        or path == "/showcase"
     ):
         return await call_next(request)
-    if not user:
-        return RedirectResponse(url="/login")
+    if user.get("role") == "guest":
+        return RedirectResponse(url="/showcase")
     admin_paths = [
         "/upload",
         "/upload_wizard",

--- a/tests/test_guest_access.py
+++ b/tests/test_guest_access.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# Disable testing shortcut to exercise the middleware during these tests
+ORIG_TESTING = os.environ.pop("TESTING", None)
+
+import main
+
+client = TestClient(main.app)
+
+
+def test_guest_showcase_access():
+    os.environ.pop("TESTING", None)
+    resp = client.get("/showcase")
+    assert resp.status_code == 200
+    assert "Model Showcase" in resp.text
+    os.environ["TESTING"] = "1"
+
+
+def test_guest_redirect_to_showcase():
+    os.environ.pop("TESTING", None)
+    resp = client.get("/grid")
+    assert resp.history and resp.history[0].status_code == 307
+    assert resp.url.path == "/showcase"
+    os.environ["TESTING"] = "1"


### PR DESCRIPTION
## Summary
- create "Model Showcase" page and route
- treat unauthenticated users as guests
- show restricted nav links for guests
- add showcase template and rendering
- allow SQLite use across threads
- test guest access behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d012a30883338284e77786526441