### PR TITLE
Add guest gallery detail view

### DIFF
--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -129,6 +129,17 @@ async def showcase(request: Request):
     return frontend.render_showcase(entries, user=request.state.user)
 
 
+@router.get("/showcase_detail/{filename}", response_class=HTMLResponse)
+async def showcase_detail(request: Request, filename: str):
+    """Guest accessible detail view for ``filename``."""
+    results = indexer.search(f'"{filename}"')
+    entry = results[0] if results else {"filename": filename}
+    meta = extractor.extract(Path(uploader.upload_dir) / filename)
+    entry["metadata"] = meta
+    entry["categories"] = indexer.get_categories_with_ids(filename)
+    return frontend.render_detail(entry, categories=[], user=request.state.user)
+
+
 @router.get("/categories")
 async def list_categories():
     return indexer.list_categories()

--- a/loradb/templates/showcase.html
+++ b/loradb/templates/showcase.html
@@ -3,10 +3,15 @@
 <h1 class="mb-4">Model Showcase</h1>
 <div class="gallery-grid">
   {% for entry in entries %}
-  <div class="gallery-item">
+  <div class="gallery-item position-relative">
     {% if entry.preview_url %}
     <img src="{{ entry.preview_url }}" alt="preview">
     {% endif %}
+    <div class="title-overlay">
+      <a href="/showcase_detail/{{ entry.filename }}" class="stretched-link text-light text-decoration-none">
+        {{ entry.name or entry.filename }}
+      </a>
+    </div>
   </div>
   {% endfor %}
 </div>

--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ async def auth_middleware(request: Request, call_next):
         or path.startswith("/uploads")
         or path.startswith("/login")
         or path == "/showcase"
+        or path.startswith("/showcase_detail")
     ):
         return await call_next(request)
     if user.get("role") == "guest":

--- a/tests/test_guest_access.py
+++ b/tests/test_guest_access.py
@@ -25,3 +25,11 @@ def test_guest_redirect_to_showcase():
     assert resp.history and resp.history[0].status_code == 307
     assert resp.url.path == "/showcase"
     os.environ["TESTING"] = "1"
+
+
+def test_guest_showcase_detail_access():
+    os.environ.pop("TESTING", None)
+    resp = client.get("/showcase_detail/test.safetensors")
+    assert resp.status_code == 200
+    assert "Download" in resp.text
+    os.environ["TESTING"] = "1"


### PR DESCRIPTION
## Summary
- show model names in Model Showcase
- link showcase items to a guest-accessible detail view
- allow `/showcase_detail` path through the auth middleware
- add tests for guest detail route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d4aa4278833382f29b62e60a57ba