### PR TITLE
Simplify showcase detail view

### DIFF
--- a/loradb/agents/frontend_agent.py
+++ b/loradb/agents/frontend_agent.py
@@ -100,6 +100,22 @@ class FrontendAgent:
             user=user,
         )
 
+    def render_showcase_detail(
+        self,
+        entry: Dict[str, str],
+        user: Dict[str, str] | None = None,
+    ) -> str:
+        """Render a simplified detail view used for the public showcase."""
+        stem = Path(entry.get("filename", "")).stem
+        previews = self._find_previews(stem)
+        entry["previews"] = previews
+        template = self.env.get_template("showcase_detail.html")
+        return template.render(
+            title=entry.get("name"),
+            entry=entry,
+            user=user,
+        )
+
     def render_category_admin(
         self, categories: List[Dict[str, str]], user: Dict[str, str] | None = None
     ) -> str:

--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -134,10 +134,7 @@ async def showcase_detail(request: Request, filename: str):
     """Guest accessible detail view for ``filename``."""
     results = indexer.search(f'"{filename}"')
     entry = results[0] if results else {"filename": filename}
-    meta = extractor.extract(Path(uploader.upload_dir) / filename)
-    entry["metadata"] = meta
-    entry["categories"] = indexer.get_categories_with_ids(filename)
-    return frontend.render_detail(entry, categories=[], user=request.state.user)
+    return frontend.render_showcase_detail(entry, user=request.state.user)
 
 
 @router.get("/categories")

--- a/loradb/templates/showcase_detail.html
+++ b/loradb/templates/showcase_detail.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">{{ entry.name or entry.filename }}</h1>
+<div class="preview-grid mb-3">
+  {% for img in entry.previews %}
+  <div class="position-relative">
+    <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/tests/test_guest_access.py
+++ b/tests/test_guest_access.py
@@ -31,5 +31,6 @@ def test_guest_showcase_detail_access():
     os.environ.pop("TESTING", None)
     resp = client.get("/showcase_detail/test.safetensors")
     assert resp.status_code == 200
-    assert "Download" in resp.text
+    assert "Download" not in resp.text
+    assert "metadata-table" not in resp.text
     os.environ["TESTING"] = "1"


### PR DESCRIPTION
## Summary
- add simplified template for showcase detail page
- render the new template without metadata or download links
- expose `render_showcase_detail` in frontend agent
- adjust guest access test accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d6ceefd08333a762b8d35d85cb1b