### PR TITLE
Implement HTML 404 page

### DIFF
--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -249,9 +249,12 @@ async def grid(request: Request):
 
 @router.get("/detail/{filename}", response_class=HTMLResponse)
 async def detail(request: Request, filename: str):
+    file_path = Path(uploader.upload_dir) / filename
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="not found")
     results = indexer.search(f'"{filename}"')
     entry = results[0] if results else {"filename": filename}
-    meta = extractor.extract(Path(uploader.upload_dir) / filename)
+    meta = extractor.extract(file_path)
     entry["metadata"] = meta
     entry["categories"] = indexer.get_categories_with_ids(filename)
     categories = indexer.list_categories()

--- a/loradb/templates/404.html
+++ b/loradb/templates/404.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="text-center">
+  <h1 class="display-4 mb-3">File Not Found</h1>
+  <p class="lead">Awww, this file may not be found, yes.</p>
+  <p>Return to <a href="/">the homepage</a>, you must.</p>
+</div>
+{% endblock %}

--- a/tests/test_guest_access.py
+++ b/tests/test_guest_access.py
@@ -34,3 +34,10 @@ def test_guest_showcase_detail_access():
     assert "Download" not in resp.text
     assert "metadata-table" not in resp.text
     os.environ["TESTING"] = "1"
+
+
+def test_custom_404_page():
+    os.environ["TESTING"] = "1"
+    resp = client.get("/no_such_page", headers={"accept": "text/html"})
+    assert resp.status_code == 404
+    assert "Awww" in resp.text


### PR DESCRIPTION
## Summary
- add template for missing pages
- show custom HTML page for 404 errors
- validate files exist for detail view
- test custom 404 page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867dfcd44d08333bee91c3524a3027f