### PR TITLE
Add Yoda themed Access Denied page

### DIFF
--- a/loradb/templates/access_denied.html
+++ b/loradb/templates/access_denied.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1 class="mb-4">Access Denied</h1>
-<p>You do not have permission to view this page.</p>
-<a class="btn btn-primary" href="/">Back to Home</a>
+<div class="text-center">
+  <h1 class="display-4 mb-3">Access Denied</h1>
+  <p class="lead">Access, you seek. Permission, you have not.</p>
+  <p>A faux pas this is. Return to <a href="/">safer ground</a>, you must.</p>
+</div>
 {% endblock %}


### PR DESCRIPTION
## 📄 Description
- give the Access Denied page the same Yoda treatment as the 404 page
- add regression test for the new text

## 🧪 Testing
- `pip install -r /tmp/req_without_torch.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e52c85c08333bfc3914c3d456fb0