### PR TITLE
Display custom 404 image

### DIFF
--- a/loradb/templates/404.html
+++ b/loradb/templates/404.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="text-center">
   <h1 class="display-4 mb-3">File Not Found</h1>
-  <p class="lead">Awww, this file may not be found, yes.</p>
-  <p>Return to <a href="/">the homepage</a>, you must.</p>
+  <img src="/static/404.jpg" width="720" height="960" class="img-fluid rounded shadow" alt="File Not Found">
+  <p class="mt-3"><a href="/">Return to the homepage</a></p>
 </div>
 {% endblock %}

--- a/tests/test_guest_access.py
+++ b/tests/test_guest_access.py
@@ -40,7 +40,7 @@ def test_custom_404_page():
     os.environ["TESTING"] = "1"
     resp = client.get("/no_such_page", headers={"accept": "text/html"})
     assert resp.status_code == 404
-    assert "Awww" in resp.text
+    assert "/static/404.jpg" in resp.text
 
 
 def test_access_denied_page_for_user():


### PR DESCRIPTION
## 📄 Description
Replaced the textual message on the 404 error page with an image found at `loradb/static/404.jpg`. The page now shows the image with a link back to the homepage and fits using explicit dimensions. Updated the corresponding test to look for the image instead of the old text.

## 🔌 Type of Change
- [ ] ✨ New feature / plugin
- [ ] 🐛 Bugfix
- [ ] 🧹 Code cleanup / refactor
- [ ] 📝 Documentation update
- [x] ✅ Test improvement
- [ ] ⚙️ Other

## 🧪 Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867e7d9b0448333b954ca030d946d3b