### PR TITLE
Update highlights in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ Link -> https://www.turtlesai.com/en/pages-2946/mylora-intelligent-and-comprehen
 - **Upload wizard** – drag & drop a LoRA file and its previews in one go.
 - **Automatic metadata extraction** – tags, dimension and other information are parsed from the model files.
 - **Searchable gallery** – browse all models, filter by tag or category and download directly.
+- **User accounts** – login/logout with role-based permissions and secure session cookies.
+- **Guest mode** – visitors are redirected to a public "Model Showcase" with preview-only details.
 - **Category management** – create and assign categories with just a few clicks.
 - **Bulk category assignment** – select multiple LoRAs in the gallery and add them to a category.
 - **Local migration** – scripts are included to import existing collections or migrate old category files.
+- **Admin tools** – manage users from the web UI and create the initial admin via `usersetup.py`.
+- **Themed error pages** – friendly 404 page and access denied view.
 - **Responsive design** – works great on desktop and mobile.
 
 ## Coming soon: Plugin support (Delayed)


### PR DESCRIPTION
## Summary
- mention user accounts, guest mode, admin tools and error pages in highlights

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6867f329dcac8333bbc8d8e4f2d23664