### PR TITLE
Add preview lightbox

### DIFF
--- a/loradb/static/lightbox.js
+++ b/loradb/static/lightbox.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('previewModal');
+  if (!modalEl) return;
+  const modal = new bootstrap.Modal(modalEl);
+  const modalImg = document.getElementById('modalImage');
+  const images = Array.from(document.querySelectorAll('.preview-grid img'));
+  let current = 0;
+
+  function show(index) {
+    if (index < 0 || index >= images.length) return;
+    current = index;
+    modalImg.src = images[current].src;
+    modal.show();
+  }
+
+  images.forEach((img, idx) => {
+    img.style.cursor = 'pointer';
+    img.addEventListener('click', () => show(idx));
+  });
+
+  document.getElementById('prevBtn').addEventListener('click', () => {
+    show((current - 1 + images.length) % images.length);
+  });
+
+  document.getElementById('nextBtn').addEventListener('click', () => {
+    show((current + 1) % images.length);
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (!modalEl.classList.contains('show')) return;
+    if (e.key === 'ArrowLeft') {
+      show((current - 1 + images.length) % images.length);
+    } else if (e.key === 'ArrowRight') {
+      show((current + 1) % images.length);
+    } else if (e.key === 'Escape') {
+      modal.hide();
+    }
+  });
+});

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -53,7 +53,7 @@
   <div class="preview-grid mb-3">
     {% for img in entry.previews %}
     <div class="position-relative">
-      <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
+      <img src="{{ img }}" class="img-fluid rounded" alt="preview">
       <input class="form-check-input position-absolute top-0 end-0 m-1" type="checkbox" name="files" value="{{ img|replace('/uploads/','') }}">
     </div>
     {% endfor %}
@@ -63,7 +63,7 @@
 <div class="preview-grid mb-3">
   {% for img in entry.previews %}
   <div class="position-relative">
-    <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
+    <img src="{{ img }}" class="img-fluid rounded" alt="preview">
   </div>
   {% endfor %}
 </div>
@@ -77,4 +77,20 @@
     </tbody>
   </table>
 </div>
+<!-- Lightbox Modal for preview images -->
+<div class="modal fade" id="previewModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content bg-dark">
+      <div class="modal-header border-0">
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center position-relative p-0">
+        <button class="btn btn-secondary position-absolute top-50 start-0 translate-middle-y" id="prevBtn" type="button">&#8249;</button>
+        <img id="modalImage" src="" class="img-fluid rounded" alt="preview">
+        <button class="btn btn-secondary position-absolute top-50 end-0 translate-middle-y" id="nextBtn" type="button">&#8250;</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="/static/lightbox.js"></script>
 {% endblock %}

--- a/loradb/templates/showcase_detail.html
+++ b/loradb/templates/showcase_detail.html
@@ -4,8 +4,24 @@
 <div class="preview-grid mb-3">
   {% for img in entry.previews %}
   <div class="position-relative">
-    <a href="{{ img }}" target="_blank"><img src="{{ img }}" class="img-fluid rounded"></a>
+    <img src="{{ img }}" class="img-fluid rounded" alt="preview">
   </div>
   {% endfor %}
 </div>
+<!-- Lightbox Modal for preview images -->
+<div class="modal fade" id="previewModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content bg-dark">
+      <div class="modal-header border-0">
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center position-relative p-0">
+        <button class="btn btn-secondary position-absolute top-50 start-0 translate-middle-y" id="prevBtn" type="button">&#8249;</button>
+        <img id="modalImage" src="" class="img-fluid rounded" alt="preview">
+        <button class="btn btn-secondary position-absolute top-50 end-0 translate-middle-y" id="nextBtn" type="button">&#8250;</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="/static/lightbox.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement a lightbox for preview images with keyboard navigation
- support lightbox on both detail pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f54bd2cd883339924c4bf42efb10a