### PR TITLE
Fix Lightbox not opening images

### DIFF
--- a/loradb/static/lightbox.js
+++ b/loradb/static/lightbox.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+function initLightbox() {
   const modalEl = document.getElementById('previewModal');
   if (!modalEl) return;
   const modal = new bootstrap.Modal(modalEl);
@@ -36,4 +36,10 @@ document.addEventListener('DOMContentLoaded', () => {
       modal.hide();
     }
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initLightbox);
+} else {
+  initLightbox();
+}


### PR DESCRIPTION
## Summary
- initialize lightbox script immediately if DOMContentLoaded already fired

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f641d48d8833393fd5894afee2d19