### PR TITLE
Fix lightbox initialization order

### DIFF
--- a/loradb/templates/base.html
+++ b/loradb/templates/base.html
@@ -47,5 +47,6 @@
       Powered by <a href="https://github.com/AsaTyr2018/MyLora" target="_blank">Asatyr</a>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Zenh87qX5JnK2JlAKP93w4Koyr5u5a63Y9Vn0eE5t0XKFuNHK08Kf+X8DP0Fi5yw" crossorigin="anonymous"></script>
+    {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/loradb/templates/detail.html
+++ b/loradb/templates/detail.html
@@ -92,5 +92,7 @@
     </div>
   </div>
 </div>
+{% endblock %}
+{% block scripts %}
 <script src="/static/lightbox.js"></script>
 {% endblock %}

--- a/loradb/templates/showcase_detail.html
+++ b/loradb/templates/showcase_detail.html
@@ -23,5 +23,7 @@
     </div>
   </div>
 </div>
+{% endblock %}
+{% block scripts %}
 <script src="/static/lightbox.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a `scripts` block to `base.html`
- move lightbox script into `scripts` block for detail pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f68ce6de8833393f136a2e1b55274