### PR TITLE
Add duplicate upload check

### DIFF
--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -192,7 +192,8 @@ curl -X POST -F "filename=awesome_lora.safetensors" -F "category_id=1" \
 ## 8. `/upload` (POST)
 
 Upload one or more `.safetensors` files. The request must be a multipart form
-with `files` as the field name.
+with `files` as the field name. If a file with the exact same name already
+exists the request fails with HTTP status `409`.
 
 **Example call**
 

--- a/docs/upload_guide.md
+++ b/docs/upload_guide.md
@@ -17,7 +17,7 @@ The wizard is the easiest way when you want to upload a new LoRA along with its 
 
 Two separate pages are available for small manual uploads:
 
-- `http://{serverip}:5000/upload` – Select one or multiple `.safetensors` files and submit the form.
+- `http://{serverip}:5000/upload` – Select one or multiple `.safetensors` files and submit the form. If a file with the same name already exists the upload is rejected with an error.
 - `http://{serverip}:5000/upload_previews` – Upload preview images for an existing LoRA or a ZIP archive containing previews. If you pass a `lora` query parameter the form will automatically target that LoRA.
 
 After sending the previews you can go to `/detail/<filename>` to review the images and metadata.

--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -54,7 +54,10 @@ async def upload_wizard_form(request: Request):
 
 @router.post("/upload")
 async def upload(request: Request, files: list[UploadFile] = File(...)):
-    saved_paths = uploader.save_files(files)
+    try:
+        saved_paths = uploader.save_files(files)
+    except FileExistsError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
     results = []
     for path in saved_paths:
         meta = extractor.extract(Path(path))

--- a/tests/test_duplicate_upload.py
+++ b/tests/test_duplicate_upload.py
@@ -1,0 +1,22 @@
+import io
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from loradb.agents.uploader_agent import UploaderAgent
+
+
+class DummyFile(SimpleNamespace):
+    def __init__(self, filename: str, data: bytes = b"test"):
+        super().__init__(filename=filename, file=io.BytesIO(data))
+
+
+def test_duplicate_lora_rejected(tmp_path):
+    agent = UploaderAgent(upload_dir=tmp_path)
+    agent.save_files([DummyFile("model.safetensors")])
+    with pytest.raises(FileExistsError):
+        agent.save_files([DummyFile("model.safetensors")])


### PR DESCRIPTION
## Summary
- add duplicate check in `UploaderAgent.save_files`
- return HTTP 409 on duplicate upload
- document duplicate behaviour in API and upload guide
- test for duplicate uploads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871462a2bbc8333ac1c988276c896ee