### PR TITLE
Fix filename lookup to avoid collisions

### DIFF
--- a/loradb/api/__init__.py
+++ b/loradb/api/__init__.py
@@ -135,8 +135,9 @@ async def showcase(request: Request):
 @router.get("/showcase_detail/{filename}", response_class=HTMLResponse)
 async def showcase_detail(request: Request, filename: str):
     """Guest accessible detail view for ``filename``."""
-    results = indexer.search(f'"{filename}"')
-    entry = results[0] if results else {"filename": filename}
+    entry = indexer.get_entry(filename)
+    if not entry:
+        entry = {"filename": filename}
     return frontend.render_showcase_detail(entry, user=request.state.user)
 
 
@@ -255,8 +256,9 @@ async def detail(request: Request, filename: str):
     file_path = Path(uploader.upload_dir) / filename
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="not found")
-    results = indexer.search(f'"{filename}"')
-    entry = results[0] if results else {"filename": filename}
+    entry = indexer.get_entry(filename)
+    if not entry:
+        entry = {"filename": filename}
     meta = extractor.extract(file_path)
     entry["metadata"] = meta
     entry["categories"] = indexer.get_categories_with_ids(filename)

--- a/tests/test_exact_filename_lookup.py
+++ b/tests/test_exact_filename_lookup.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from loradb.agents.indexing_agent import IndexingAgent
+
+
+def test_exact_filename_lookup(tmp_path):
+    db = tmp_path / "index.db"
+    indexer = IndexingAgent(db_path=db)
+
+    indexer.add_metadata({"filename": "ChillinDifferentWorld_Blossom.safetensors"})
+    indexer.add_metadata({"filename": "Blossom.safetensors"})
+
+    entry = indexer.get_entry("Blossom.safetensors")
+    assert entry is not None
+    assert entry["filename"] == "Blossom.safetensors"


### PR DESCRIPTION
## Summary
- add `get_entry` helper for exact filename lookup
- use `get_entry` in detail and showcase endpoints
- test that similar filenames resolve correctly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873bb84a6a48333bb52f6ea32f040c5