### PR TITLE
Add lazy client for on-demand file download

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,24 @@
+# MyLora Lazy Client
+
+This utility mirrors LoRA files from a running MyLora instance. It creates
+0-byte placeholder files that are replaced with the real `.safetensors` on
+first access.
+
+## Configuration
+
+Edit `config.toml`:
+
+```toml
+server_url = "http://127.0.0.1:5000"  # URL of your MyLora server
+data_dir = "./lora_mount"              # Directory for placeholders and downloads
+```
+
+## Usage
+
+```
+python client.py
+```
+
+A watcher thread listens for file open events in `data_dir`. When a placeholder
+is opened it downloads the real file from `server_url`. After 60 seconds of
+inactivity the file is removed and a placeholder is recreated.

--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,0 +1,1 @@
+"Client module"

--- a/client/client.py
+++ b/client/client.py
@@ -1,0 +1,99 @@
+"""Lazy LoRA downloader client.
+
+This small helper mirrors remote `.safetensors` files as 0-byte placeholders.
+When an application opens a placeholder, the file is fetched from the MyLora
+server and stored locally until it has not been accessed for a while.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Dict
+
+import httpx
+from inotify_simple import INotify, flags
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python <3.11 fallback
+    import tomli as tomllib
+
+CONFIG_PATH = Path(__file__).with_name("config.toml")
+
+
+class LazyDownloader:
+    """Monitor placeholder files and download them on demand."""
+
+    def __init__(self, server_url: str, data_dir: Path, expire_seconds: int = 60):
+        self.server_url = server_url.rstrip("/")
+        self.data_dir = data_dir
+        self.expire_seconds = expire_seconds
+        self.access_times: Dict[Path, float] = {}
+        self.inotify = INotify()
+        self.inotify.add_watch(str(self.data_dir), flags.OPEN | flags.CLOSE)
+
+    def ensure_placeholders(self) -> None:
+        resp = httpx.get(f"{self.server_url}/search", params={"query": "*"})
+        resp.raise_for_status()
+        for entry in resp.json():
+            path = self.data_dir / entry["filename"]
+            path.touch(exist_ok=True)
+
+    def download(self, name: str) -> None:
+        url = f"{self.server_url}/uploads/{name}"
+        resp = httpx.get(url)
+        resp.raise_for_status()
+        (self.data_dir / name).write_bytes(resp.content)
+
+    def cleanup(self) -> None:
+        now = time.time()
+        for path, ts in list(self.access_times.items()):
+            if (
+                now - ts > self.expire_seconds
+                and path.exists()
+                and path.stat().st_size > 0
+            ):
+                path.unlink(missing_ok=True)
+                path.touch()
+                del self.access_times[path]
+
+    def run(self) -> None:
+        self.ensure_placeholders()
+        while True:
+            for event in self.inotify.read(timeout=1000):
+                path = self.data_dir / event.name
+                if event.mask & flags.OPEN:
+                    if path.stat().st_size == 0:
+                        self.download(event.name)
+                    self.access_times[path] = time.time()
+                elif event.mask & flags.CLOSE:
+                    self.access_times[path] = time.time()
+            self.cleanup()
+
+
+def load_config() -> tuple[str, Path]:
+    with CONFIG_PATH.open("rb") as fh:
+        cfg = tomllib.load(fh)
+    server_url = cfg.get("server_url", "http://127.0.0.1:5000")
+    data_dir = Path(cfg.get("data_dir", "./lora_mount"))
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return server_url, data_dir
+
+
+def main() -> None:
+    server, data_dir = load_config()
+    downloader = LazyDownloader(server, data_dir)
+    thread = threading.Thread(target=downloader.run, daemon=True)
+    thread.start()
+    print(f"Listening for accesses in {data_dir} (Ctrl+C to stop)")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Stopping...")
+
+
+if __name__ == "__main__":
+    main()

--- a/client/config.toml
+++ b/client/config.toml
@@ -1,0 +1,2 @@
+server_url = "http://127.0.0.1:5000"
+data_dir = "./lora_mount"


### PR DESCRIPTION
## Summary
- add a new `client` folder with a placeholder-based sync helper
- include configuration via `config.toml`
- document usage in `client/README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_687ba4ccd1588333bbcc55211a1b654d