### PR TITLE
Add requirements for client

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -4,6 +4,14 @@ This utility mirrors LoRA files from a running MyLora instance. It creates
 0-byte placeholder files that are replaced with the real `.safetensors` on
 first access.
 
+## Installation
+
+Install the client dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Configuration
 
 Edit `config.toml`:

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,0 +1,3 @@
+httpx
+inotify_simple
+tomli; python_version < '3.11'


### PR DESCRIPTION
## Summary
- document how to install dependencies for the lazy client
- add a dedicated requirements file for the client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687baec6223c8333ba8f9a5eae96182f