### PR TITLE
Add login for lazy client

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -19,7 +19,13 @@ Edit `config.toml`:
 ```toml
 server_url = "http://127.0.0.1:5000"  # URL of your MyLora server
 data_dir = "./lora_mount"              # Directory for placeholders and downloads
+username = ""                          # Optional: user name for /login
+password = ""                          # Optional: password for /login
 ```
+
+If `username` and `password` are provided, the client performs a login against
+`/login` before requesting any files. Leaving them blank keeps guest mode which
+only allows access to the public showcase.
 
 ## Usage
 

--- a/client/config.toml
+++ b/client/config.toml
@@ -1,2 +1,5 @@
 server_url = "http://127.0.0.1:5000"
 data_dir = "./lora_mount"
+# Optional login credentials. Leave empty for guest access.
+username = ""
+password = ""


### PR DESCRIPTION
## Summary
- extend LazyDownloader to optionally login via `/login`
- load credentials from `config.toml`
- document new options in client README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb3730244833399ecafcf392d2a44