### PR TITLE
Fix login handling in lazy client

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -78,7 +78,11 @@ class LazyDownloader:
                 f"{self.server_url}/login",
                 data={"username": self.username, "password": self.password},
             )
-            resp.raise_for_status()
+            # Successful login issues a 303 redirect to "/". Treat this as
+            # success instead of raising an exception when ``follow_redirects``
+            # is disabled.
+            if resp.status_code != 303:
+                resp.raise_for_status()
         self.ensure_placeholders()
         while True:
             for event in self.inotify.read(timeout=1000):


### PR DESCRIPTION
## 📄 Description
- treat 303 redirect after `/login` as a success in the lazy client

## 🔌 Type of Change
- [x] 🐛 Bugfix

## 🧪 Testing
- `isort client/client.py`
- `black client/client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c0563dd08833393da7b6758af9f11