### PR TITLE
Stream MyLora exporter entries sequentially

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -8,3 +8,11 @@
    - General Description: Delivered a command-line exporter that mirrors all online LoRAs, their previews, and metadata for offline archives.
    - Technical Changes: Added `export_loras.py` with authentication-aware downloads and updated the README with usage instructions.
    - Data Changes: Documented the generated `exported_loras.txt` report that captures exported LoRA names with associated tags and categories.
+3. [Fix] Hardened offline exporter against slow responses
+   - General Description: Resolved timeouts encountered when exporting from slower or remote MyLora instances by making the HTTP client more resilient.
+   - Technical Changes: Introduced configurable request timeouts, retry logic with exponential backoff, and CLI flags to override connection settings.
+   - Data Changes: Updated README guidance to document the new exporter options and behaviour.
+4. [Fix] Sequential offline export pagination
+   - General Description: Prevented the exporter from loading thousands of LoRAs into memory at once by iterating through the catalogue in batches.
+   - Technical Changes: Added a streaming `iter_entries` helper, a configurable batch size flag, and sequential counting to keep the process responsive for very large datasets.
+   - Data Changes: Documented the sequential export behaviour and batch tuning guidance in the README.

--- a/README.md
+++ b/README.md
@@ -112,14 +112,20 @@ python bulk_import.py SAFETENSORS_DIR IMAGES_DIR [CATEGORIES_DIR]
 
 Use `export_loras.py` to mirror all models, previews, and tags for offline use:
 
-1. Configure `MYLORA_HOST`, `MYLORA_USERNAME`, and `MYLORA_PASSWORD` at the top of the script.
-2. Run the exporter with the target directory for your archive.
+1. Either configure `MYLORA_HOST`, `MYLORA_USERNAME`, and `MYLORA_PASSWORD` at the top of the script **or** override them via command-line flags.
+2. Run the exporter with the target directory for your archive. Adjust the timeout, retry behaviour, and batch size to match your server speed if necessary.
 
 ```bash
-python export_loras.py /path/to/export
+python export_loras.py /path/to/export \
+  --host http://127.0.0.1:5000 \
+  --username mylora_admin \
+  --password secret \
+  --timeout 60 \
+  --retries 5 \
+  --batch-size 250
 ```
 
-Each LoRA is stored in its own folder containing the `.safetensors` file and a `<name>-Images` subdirectory with previews. A generated `exported_loras.txt` lists every successfully exported model along with its tags and categories.
+The exporter walks the catalogue sequentially, requesting manageable batches so that thousands of LoRAs can be mirrored without keeping the entire listing in memory. Requests that run into read timeouts are retried using an exponential backoff, helping the process succeed even on slower connections. Each LoRA is stored in its own folder containing the `.safetensors` file and a `<name>-Images` subdirectory with previews. A generated `exported_loras.txt` lists every successfully exported model along with its tags and categories.
 
 ## Category migration
 Convert old `<name>.txt` files in `loradb/uploads` to the new database format with:


### PR DESCRIPTION
## Summary
- add a streaming `iter_entries` helper so the exporter walks MyLora listings in manageable batches
- expose a configurable `--batch-size` flag and update the CLI flow to process entries sequentially
- document the sequential export behaviour and record the fix in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d52548d1b4833381fce32c7779fc0c